### PR TITLE
[DV-86] feat : 면접 평가 기능 구현

### DIFF
--- a/src/main/java/org/richardstallman/dvback/client/python/PythonService.java
+++ b/src/main/java/org/richardstallman/dvback/client/python/PythonService.java
@@ -1,9 +1,13 @@
 package org.richardstallman.dvback.client.python;
 
+import org.richardstallman.dvback.domain.evaluation.domain.external.request.EvaluationExternalRequestDto;
+import org.richardstallman.dvback.domain.evaluation.domain.external.response.EvaluationExternalResponseDto;
 import org.richardstallman.dvback.domain.question.domain.external.request.QuestionExternalRequestDto;
 import org.richardstallman.dvback.domain.question.domain.external.response.QuestionExternalResponseDto;
 
 public interface PythonService {
 
   QuestionExternalResponseDto getInterviewQuestions(QuestionExternalRequestDto requestDto);
+
+  EvaluationExternalResponseDto getOverallEvaluations(EvaluationExternalRequestDto requestDto);
 }

--- a/src/main/java/org/richardstallman/dvback/client/python/PythonServiceImpl.java
+++ b/src/main/java/org/richardstallman/dvback/client/python/PythonServiceImpl.java
@@ -25,6 +25,12 @@ public class PythonServiceImpl implements PythonService {
   @Value("${python.server.url}")
   private String pythonServerUrl;
 
+  @Value("${python.server.question-path}")
+  private String pythonServerQuestionPath;
+
+  @Value("${python.server.evaluation-path}")
+  private String pythonServerEvaluationPath;
+
   @Override
   public QuestionExternalResponseDto getInterviewQuestions(QuestionExternalRequestDto requestDto) {
     HttpHeaders headers = new HttpHeaders();
@@ -34,7 +40,7 @@ public class PythonServiceImpl implements PythonService {
 
     URI uri =
         UriComponentsBuilder.fromUriString(pythonServerUrl)
-            .path("/interview/questions")
+            .path(pythonServerQuestionPath)
             .build()
             .toUri();
 
@@ -59,7 +65,7 @@ public class PythonServiceImpl implements PythonService {
 
     URI uri =
         UriComponentsBuilder.fromUriString(pythonServerUrl)
-            .path("/interview/evaluation")
+            .path(pythonServerEvaluationPath)
             .build()
             .toUri();
 

--- a/src/main/java/org/richardstallman/dvback/client/python/PythonServiceImpl.java
+++ b/src/main/java/org/richardstallman/dvback/client/python/PythonServiceImpl.java
@@ -2,6 +2,8 @@ package org.richardstallman.dvback.client.python;
 
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import org.richardstallman.dvback.domain.evaluation.domain.external.request.EvaluationExternalRequestDto;
+import org.richardstallman.dvback.domain.evaluation.domain.external.response.EvaluationExternalResponseDto;
 import org.richardstallman.dvback.domain.question.domain.external.request.QuestionExternalRequestDto;
 import org.richardstallman.dvback.domain.question.domain.external.response.QuestionExternalResponseDto;
 import org.springframework.beans.factory.annotation.Value;
@@ -39,6 +41,31 @@ public class PythonServiceImpl implements PythonService {
     ResponseEntity<QuestionExternalResponseDto> response =
         restTemplate.exchange(
             uri, HttpMethod.POST, requestEntity, QuestionExternalResponseDto.class);
+
+    if (response.getStatusCode().is2xxSuccessful()) {
+      return response.getBody();
+    } else {
+      throw new RuntimeException("Failed to connect to Python server");
+    }
+  }
+
+  @Override
+  public EvaluationExternalResponseDto getOverallEvaluations(
+      EvaluationExternalRequestDto requestDto) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+
+    HttpEntity<EvaluationExternalRequestDto> requestEntity = new HttpEntity<>(requestDto, headers);
+
+    URI uri =
+        UriComponentsBuilder.fromUriString(pythonServerUrl)
+            .path("/interview/evaluation")
+            .build()
+            .toUri();
+
+    ResponseEntity<EvaluationExternalResponseDto> response =
+        restTemplate.exchange(
+            uri, HttpMethod.POST, requestEntity, EvaluationExternalResponseDto.class);
 
     if (response.getStatusCode().is2xxSuccessful()) {
       return response.getBody();

--- a/src/main/java/org/richardstallman/dvback/common/constant/CommonConstants.java
+++ b/src/main/java/org/richardstallman/dvback/common/constant/CommonConstants.java
@@ -1,5 +1,6 @@
 package org.richardstallman.dvback.common.constant;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -16,40 +17,31 @@ public class CommonConstants {
   }
 
   @Getter
+  @AllArgsConstructor
   public enum InterviewType {
     TECHNICAL("technical"), // 기술 면접
     PERSONAL("personal"); // 인성 면접
 
     private final String pythonFormat;
-
-    InterviewType(String pythonFormat) {
-      this.pythonFormat = pythonFormat;
-    }
   }
 
   @Getter
+  @AllArgsConstructor
   public enum InterviewMode {
     REAL("real"), // 실전 면접 모드
     GENERAL("general"); // 일반/모의 면접 모드
 
     private final String pythonFormat;
-
-    InterviewMode(String pythonFormat) {
-      this.pythonFormat = pythonFormat;
-    }
   }
 
   @Getter
+  @AllArgsConstructor
   public enum InterviewMethod {
     CHAT("chat"), // 채팅 면접
     VOICE("voice"), // 음성 면접
     VIDEO("video"); // 영상 면접
 
     private final String pythonFormat;
-
-    InterviewMethod(String pythonFormat) {
-      this.pythonFormat = pythonFormat;
-    }
   }
 
   @AllArgsConstructor
@@ -63,5 +55,18 @@ public class CommonConstants {
 
     private final int code;
     private final String message;
+  }
+
+  @Getter
+  @AllArgsConstructor
+  @JsonFormat(shape = JsonFormat.Shape.STRING)
+  public enum EvaluationCriteria {
+    ANSWER("answer"),
+    DEVELOPMENT_SKILL("development_skill"),
+    GROWTH_POTENTIAL("growth_potential"),
+    TECHNICAL_DEPTH("technical_depth"),
+    WORK_ATTITUDE("work_attitude");
+
+    private final String pythonFormat;
   }
 }

--- a/src/main/java/org/richardstallman/dvback/domain/answer/converter/AnswerConverter.java
+++ b/src/main/java/org/richardstallman/dvback/domain/answer/converter/AnswerConverter.java
@@ -23,6 +23,14 @@ public class AnswerConverter {
         answerDomain.getS3VideoUrl());
   }
 
+  public AnswerEntity fromDomainToEntityWhenCreate(AnswerDomain answerDomain) {
+    return new AnswerEntity(
+        questionConverter.fromDomainToEntity(answerDomain.getQuestionDomain()),
+        answerDomain.getAnswerText(),
+        answerDomain.getS3AudioUrl(),
+        answerDomain.getS3VideoUrl());
+  }
+
   public AnswerDomain fromEntityToDomain(AnswerEntity answerEntity) {
     return AnswerDomain.builder()
         .answerId(answerEntity.getAnswerId())
@@ -39,7 +47,7 @@ public class AnswerConverter {
         .questionDomain(questionDomain)
         .answerText(answerPreviousRequestDto.answerText())
         .s3AudioUrl(answerPreviousRequestDto.s3AudioUrl())
-        .s3VideoUrl(questionDomain.getS3VideoUrl())
+        .s3VideoUrl(answerPreviousRequestDto.s3VideoUrl())
         .build();
   }
 }

--- a/src/main/java/org/richardstallman/dvback/domain/answer/entity/AnswerEntity.java
+++ b/src/main/java/org/richardstallman/dvback/domain/answer/entity/AnswerEntity.java
@@ -38,4 +38,13 @@ public class AnswerEntity extends BaseEntity {
 
   private String s3AudioUrl;
   private String s3VideoUrl;
+
+  public AnswerEntity(
+      QuestionEntity question, String answerText, String s3AudioUrl, String s3VideoUrl) {
+    super();
+    this.question = question;
+    this.answerText = answerText;
+    this.s3AudioUrl = s3AudioUrl;
+    this.s3VideoUrl = s3VideoUrl;
+  }
 }

--- a/src/main/java/org/richardstallman/dvback/domain/answer/repository/AnswerJpaRepository.java
+++ b/src/main/java/org/richardstallman/dvback/domain/answer/repository/AnswerJpaRepository.java
@@ -5,4 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface AnswerJpaRepository extends JpaRepository<AnswerEntity, Long> {}
+public interface AnswerJpaRepository extends JpaRepository<AnswerEntity, Long> {
+
+  AnswerEntity findByQuestionQuestionId(Long questionId);
+}

--- a/src/main/java/org/richardstallman/dvback/domain/answer/repository/AnswerRepository.java
+++ b/src/main/java/org/richardstallman/dvback/domain/answer/repository/AnswerRepository.java
@@ -5,4 +5,6 @@ import org.richardstallman.dvback.domain.answer.domain.AnswerDomain;
 public interface AnswerRepository {
 
   AnswerDomain save(AnswerDomain answerDomain);
+
+  AnswerDomain findByQuestionId(Long questionId);
 }

--- a/src/main/java/org/richardstallman/dvback/domain/answer/repository/AnswerRepositoryImpl.java
+++ b/src/main/java/org/richardstallman/dvback/domain/answer/repository/AnswerRepositoryImpl.java
@@ -15,6 +15,12 @@ public class AnswerRepositoryImpl implements AnswerRepository {
   @Override
   public AnswerDomain save(AnswerDomain answerDomain) {
     return answerConverter.fromEntityToDomain(
-        answerJpaRepository.save(answerConverter.fromDomainToEntity(answerDomain)));
+        answerJpaRepository.save(answerConverter.fromDomainToEntityWhenCreate(answerDomain)));
+  }
+
+  @Override
+  public AnswerDomain findByQuestionId(Long questionId) {
+    return answerConverter.fromEntityToDomain(
+        answerJpaRepository.findByQuestionQuestionId(questionId));
   }
 }

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/controller/EvaluationController.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/controller/EvaluationController.java
@@ -1,0 +1,32 @@
+package org.richardstallman.dvback.domain.evaluation.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.richardstallman.dvback.common.DvApiResponse;
+import org.richardstallman.dvback.domain.evaluation.domain.overall.request.OverallEvaluationRequestDto;
+import org.richardstallman.dvback.domain.evaluation.domain.overall.response.OverallEvaluationResponseDto;
+import org.richardstallman.dvback.domain.evaluation.service.EvaluationService;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping(value = "/evaluation", produces = MediaType.APPLICATION_JSON_VALUE)
+public class EvaluationController {
+
+  private final EvaluationService evaluationService;
+
+  @PostMapping
+  public ResponseEntity<DvApiResponse<OverallEvaluationResponseDto>> getOverallEvaluation(
+      @Valid @RequestBody final OverallEvaluationRequestDto overallEvaluationRequestDto) {
+    final OverallEvaluationResponseDto overallEvaluationResponseDto =
+        evaluationService.getOverallEvaluation(overallEvaluationRequestDto);
+    return ResponseEntity.ok(DvApiResponse.of(overallEvaluationResponseDto));
+  }
+}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/converter/AnswerEvaluationConverter.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/converter/AnswerEvaluationConverter.java
@@ -1,0 +1,68 @@
+package org.richardstallman.dvback.domain.evaluation.converter;
+
+import org.richardstallman.dvback.domain.evaluation.domain.answer.AnswerEvaluationDomain;
+import org.richardstallman.dvback.domain.evaluation.domain.answer.response.AnswerEvaluationResponseDto;
+import org.richardstallman.dvback.domain.evaluation.domain.external.AnswerEvaluationExternalDomain;
+import org.richardstallman.dvback.domain.evaluation.domain.overall.OverallEvaluationDomain;
+import org.richardstallman.dvback.domain.evaluation.entity.answer.AnswerEvaluationEntity;
+import org.richardstallman.dvback.domain.question.converter.QuestionConverter;
+import org.richardstallman.dvback.domain.question.domain.QuestionDomain;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AnswerEvaluationConverter {
+
+  private final QuestionConverter questionConverter;
+  private final OverallEvaluationConverter overallEvaluationConverter;
+
+  @Autowired
+  public AnswerEvaluationConverter(
+      QuestionConverter questionConverter,
+      @Lazy OverallEvaluationConverter overallEvaluationConverter) {
+    this.questionConverter = questionConverter;
+    this.overallEvaluationConverter = overallEvaluationConverter;
+  }
+
+  public AnswerEvaluationEntity fromDomainToEntity(AnswerEvaluationDomain answerEvaluationDomain) {
+    return new AnswerEvaluationEntity(
+        answerEvaluationDomain.getAnswerEvaluationId(),
+        questionConverter.fromDomainToEntity(answerEvaluationDomain.getQuestionDomain()),
+        answerEvaluationDomain.getAnswerFeedbackText(),
+        answerEvaluationDomain.getScore(),
+        overallEvaluationConverter.fromDomainToEntity(
+            answerEvaluationDomain.getOverallEvaluationDomain()));
+  }
+
+  public AnswerEvaluationDomain fromEntityToDomain(AnswerEvaluationEntity answerEvaluationEntity) {
+    return AnswerEvaluationDomain.builder()
+        .answerEvaluationId(answerEvaluationEntity.getAnswerEvaluationId())
+        .questionDomain(questionConverter.fromEntityToDomain(answerEvaluationEntity.getQuestion()))
+        .answerFeedbackText(answerEvaluationEntity.getAnswerFeedbackText())
+        .score(answerEvaluationEntity.getScore())
+        .build();
+  }
+
+  public AnswerEvaluationDomain externalDomainToDomain(
+      AnswerEvaluationExternalDomain answerEvaluationExternalDomain,
+      QuestionDomain questionDomain,
+      OverallEvaluationDomain overallEvaluationDomain) {
+    return AnswerEvaluationDomain.builder()
+        .questionDomain(questionDomain)
+        .answerFeedbackText(answerEvaluationExternalDomain.getFeedbackText())
+        .score(answerEvaluationExternalDomain.getScore())
+        .overallEvaluationDomain(overallEvaluationDomain)
+        .build();
+  }
+
+  public AnswerEvaluationResponseDto fromDomainToResponseDto(
+      AnswerEvaluationDomain answerEvaluationDomain, String answerText) {
+    return new AnswerEvaluationResponseDto(
+        answerEvaluationDomain.getAnswerEvaluationId(),
+        answerEvaluationDomain.getQuestionDomain().getQuestionText(),
+        answerText,
+        answerEvaluationDomain.getAnswerFeedbackText(),
+        answerEvaluationDomain.getScore());
+  }
+}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/converter/EvaluationCriteriaConverter.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/converter/EvaluationCriteriaConverter.java
@@ -1,0 +1,47 @@
+package org.richardstallman.dvback.domain.evaluation.converter;
+
+import org.richardstallman.dvback.domain.evaluation.domain.EvaluationCriteriaDomain;
+import org.richardstallman.dvback.domain.evaluation.domain.response.EvaluationCriteriaResponseDto;
+import org.richardstallman.dvback.domain.evaluation.entity.EvaluationCriteriaEntity;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EvaluationCriteriaConverter {
+
+  private final OverallEvaluationConverter overallEvaluationConverter;
+
+  public EvaluationCriteriaConverter(@Lazy OverallEvaluationConverter overallEvaluationConverter) {
+    this.overallEvaluationConverter = overallEvaluationConverter;
+  }
+
+  public EvaluationCriteriaEntity fromDomainToEntity(
+      EvaluationCriteriaDomain evaluationCriteriaDomain) {
+    return new EvaluationCriteriaEntity(
+        evaluationCriteriaDomain.getEvaluationCriteriaId(),
+        evaluationCriteriaDomain.getEvaluationCriteria(),
+        evaluationCriteriaDomain.getFeedbackText(),
+        evaluationCriteriaDomain.getScore(),
+        overallEvaluationConverter.fromDomainToEntity(
+            evaluationCriteriaDomain.getOverallEvaluationDomain()));
+  }
+
+  public EvaluationCriteriaDomain fromEntityToDomain(
+      EvaluationCriteriaEntity evaluationCriteriaEntity) {
+    return EvaluationCriteriaDomain.builder()
+        .evaluationCriteriaId(evaluationCriteriaEntity.getEvaluationCriteriaId())
+        .evaluationCriteria(evaluationCriteriaEntity.getEvaluationCriteriaName())
+        .feedbackText(evaluationCriteriaEntity.getFeedbackText())
+        .score(evaluationCriteriaEntity.getScore())
+        .build();
+  }
+
+  public EvaluationCriteriaResponseDto fromDomainToResponseDto(
+      EvaluationCriteriaDomain evaluationCriteriaDomain) {
+    return new EvaluationCriteriaResponseDto(
+        evaluationCriteriaDomain.getEvaluationCriteriaId(),
+        evaluationCriteriaDomain.getEvaluationCriteria().name(),
+        evaluationCriteriaDomain.getFeedbackText(),
+        evaluationCriteriaDomain.getScore());
+  }
+}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/converter/OverallEvaluationConverter.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/converter/OverallEvaluationConverter.java
@@ -1,0 +1,45 @@
+package org.richardstallman.dvback.domain.evaluation.converter;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.richardstallman.dvback.domain.evaluation.domain.answer.response.AnswerEvaluationResponseDto;
+import org.richardstallman.dvback.domain.evaluation.domain.overall.OverallEvaluationDomain;
+import org.richardstallman.dvback.domain.evaluation.domain.overall.response.OverallEvaluationResponseDto;
+import org.richardstallman.dvback.domain.evaluation.domain.response.EvaluationCriteriaResponseDto;
+import org.richardstallman.dvback.domain.evaluation.entity.overall.OverallEvaluationEntity;
+import org.richardstallman.dvback.domain.interview.converter.InterviewConverter;
+import org.richardstallman.dvback.domain.interview.domain.InterviewDomain;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OverallEvaluationConverter {
+
+  private final InterviewConverter interviewConverter;
+
+  public OverallEvaluationEntity fromDomainToEntity(
+      OverallEvaluationDomain overallEvaluationDomain) {
+    return new OverallEvaluationEntity(
+        overallEvaluationDomain.getOverallEvaluationId(),
+        interviewConverter.fromDomainToEntity(overallEvaluationDomain.getInterviewDomain()));
+  }
+
+  public OverallEvaluationDomain fromEntityToDomain(
+      OverallEvaluationEntity overallEvaluationEntity) {
+    return OverallEvaluationDomain.builder()
+        .overallEvaluationId(overallEvaluationEntity.getOverallEvaluationId())
+        .interviewDomain(
+            interviewConverter.fromEntityToDomain(overallEvaluationEntity.getInterview()))
+        .build();
+  }
+
+  public OverallEvaluationResponseDto toResponseDto(
+      InterviewDomain interviewDomain,
+      List<EvaluationCriteriaResponseDto> evaluationCriteriaResponseDtos,
+      List<AnswerEvaluationResponseDto> answerEvaluationResponseDtos) {
+    return new OverallEvaluationResponseDto(
+        interviewConverter.fromDomainToDto(interviewDomain),
+        evaluationCriteriaResponseDtos,
+        answerEvaluationResponseDtos);
+  }
+}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/EvaluationCriteriaDomain.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/EvaluationCriteriaDomain.java
@@ -1,0 +1,21 @@
+package org.richardstallman.dvback.domain.evaluation.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.richardstallman.dvback.common.constant.CommonConstants.EvaluationCriteria;
+import org.richardstallman.dvback.domain.evaluation.domain.overall.OverallEvaluationDomain;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class EvaluationCriteriaDomain {
+
+  private Long evaluationCriteriaId;
+  private EvaluationCriteria evaluationCriteria;
+  private String feedbackText;
+  private int score;
+  private OverallEvaluationDomain overallEvaluationDomain;
+}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/answer/AnswerEvaluationDomain.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/answer/AnswerEvaluationDomain.java
@@ -1,0 +1,17 @@
+package org.richardstallman.dvback.domain.evaluation.domain.answer;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.richardstallman.dvback.domain.evaluation.domain.overall.OverallEvaluationDomain;
+import org.richardstallman.dvback.domain.question.domain.QuestionDomain;
+
+@Builder
+@Getter
+public class AnswerEvaluationDomain {
+
+  private final Long answerEvaluationId;
+  private final QuestionDomain questionDomain;
+  private final String answerFeedbackText;
+  private final int score;
+  private final OverallEvaluationDomain overallEvaluationDomain;
+}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/answer/response/AnswerEvaluationResponseDto.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/answer/response/AnswerEvaluationResponseDto.java
@@ -1,0 +1,10 @@
+package org.richardstallman.dvback.domain.evaluation.domain.answer.response;
+
+import jakarta.validation.constraints.NotNull;
+
+public record AnswerEvaluationResponseDto(
+    @NotNull Long answerEvaluationId,
+    @NotNull String questionText,
+    @NotNull String answerText,
+    @NotNull String answerFeedbackText,
+    @NotNull int score) {}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/external/AnswerEvaluationExternalDomain.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/external/AnswerEvaluationExternalDomain.java
@@ -1,0 +1,20 @@
+package org.richardstallman.dvback.domain.evaluation.domain.external;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class AnswerEvaluationExternalDomain {
+
+  @NotNull @JsonProperty("feedback_text")
+  String feedbackText;
+
+  @NotNull @JsonProperty("question_id")
+  long questionId;
+
+  @NotNull @JsonProperty("score")
+  int score;
+}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/external/EvaluationCriteriaExternalDomain.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/external/EvaluationCriteriaExternalDomain.java
@@ -1,0 +1,18 @@
+package org.richardstallman.dvback.domain.evaluation.domain.external;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class EvaluationCriteriaExternalDomain {
+
+  @JsonProperty("score")
+  private int score;
+
+  @JsonProperty("feedback_text")
+  private String feedbackText;
+}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/external/OverallEvaluationExternalDomain.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/external/OverallEvaluationExternalDomain.java
@@ -1,0 +1,24 @@
+package org.richardstallman.dvback.domain.evaluation.domain.external;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class OverallEvaluationExternalDomain {
+
+  @JsonProperty("development_skill")
+  private EvaluationCriteriaExternalDomain developmentSkill;
+
+  @JsonProperty("growth_potential")
+  private EvaluationCriteriaExternalDomain growthPotential;
+
+  @JsonProperty("technical_depth")
+  private EvaluationCriteriaExternalDomain technicalDepth;
+
+  @JsonProperty("work_attitude")
+  private EvaluationCriteriaExternalDomain workAttitude;
+}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/external/request/EvaluationExternalRequestDto.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/external/request/EvaluationExternalRequestDto.java
@@ -1,0 +1,45 @@
+package org.richardstallman.dvback.domain.evaluation.domain.external.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import org.richardstallman.dvback.common.constant.CommonConstants.InterviewMethod;
+import org.richardstallman.dvback.common.constant.CommonConstants.InterviewMode;
+import org.richardstallman.dvback.common.constant.CommonConstants.InterviewType;
+
+public record EvaluationExternalRequestDto(
+    @JsonProperty("cover_letter") String coverLetterS3Url,
+    @JsonProperty("questions") List<String> questions,
+    @JsonProperty("answers") List<String> answers,
+    @JsonProperty("interview_mode") String interviewMode,
+    @JsonProperty("interview_type") String interviewType,
+    @JsonProperty("interview_method") String interviewMethod,
+    @JsonProperty("job_role") String jobName) {
+
+  public EvaluationExternalRequestDto(
+      String coverLetterS3Url,
+      List<String> questions,
+      List<String> answers,
+      InterviewMode interviewMode,
+      InterviewType interviewType,
+      InterviewMethod interviewMethod,
+      String jobName) {
+    this(
+        coverLetterS3Url,
+        questions,
+        answers,
+        interviewMode.getPythonFormat(),
+        interviewType.getPythonFormat(),
+        interviewMethod.getPythonFormat(),
+        convertJobNameToPythonFormat(jobName));
+  }
+
+  private static String convertJobNameToPythonFormat(String jobName) {
+    return switch (jobName) {
+      case "BACK_END" -> "backend";
+      case "FRONTEND" -> "frontend";
+      case "INFRA" -> "infra";
+      case "AI" -> "ai";
+      default -> jobName.toLowerCase();
+    };
+  }
+}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/external/response/EvaluationExternalResponseDto.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/external/response/EvaluationExternalResponseDto.java
@@ -1,0 +1,13 @@
+package org.richardstallman.dvback.domain.evaluation.domain.external.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import org.richardstallman.dvback.domain.evaluation.domain.external.AnswerEvaluationExternalDomain;
+import org.richardstallman.dvback.domain.evaluation.domain.external.OverallEvaluationExternalDomain;
+
+public record EvaluationExternalResponseDto(
+    @NotNull @JsonProperty("answer_evaluations")
+        List<AnswerEvaluationExternalDomain> answerEvaluations,
+    @NotNull @JsonProperty("overall_evaluation")
+        OverallEvaluationExternalDomain overallEvaluation) {}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/overall/OverallEvaluationDomain.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/overall/OverallEvaluationDomain.java
@@ -1,0 +1,13 @@
+package org.richardstallman.dvback.domain.evaluation.domain.overall;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.richardstallman.dvback.domain.interview.domain.InterviewDomain;
+
+@Builder
+@Getter
+public class OverallEvaluationDomain {
+
+  private final Long overallEvaluationId;
+  private InterviewDomain interviewDomain;
+}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/overall/request/OverallEvaluationRequestDto.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/overall/request/OverallEvaluationRequestDto.java
@@ -1,0 +1,5 @@
+package org.richardstallman.dvback.domain.evaluation.domain.overall.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record OverallEvaluationRequestDto(@NotNull Long interviewId) {}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/overall/response/OverallEvaluationResponseDto.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/overall/response/OverallEvaluationResponseDto.java
@@ -1,0 +1,12 @@
+package org.richardstallman.dvback.domain.evaluation.domain.overall.response;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import org.richardstallman.dvback.domain.evaluation.domain.answer.response.AnswerEvaluationResponseDto;
+import org.richardstallman.dvback.domain.evaluation.domain.response.EvaluationCriteriaResponseDto;
+import org.richardstallman.dvback.domain.interview.domain.response.InterviewCreateResponseDto;
+
+public record OverallEvaluationResponseDto(
+    @NotNull InterviewCreateResponseDto interview,
+    @NotNull List<EvaluationCriteriaResponseDto> evaluationCriteria,
+    @NotNull List<AnswerEvaluationResponseDto> answerEvaluations) {}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/response/EvaluationCriteriaResponseDto.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/response/EvaluationCriteriaResponseDto.java
@@ -1,0 +1,9 @@
+package org.richardstallman.dvback.domain.evaluation.domain.response;
+
+import jakarta.validation.constraints.NotNull;
+
+public record EvaluationCriteriaResponseDto(
+    @NotNull Long evaluationCriteriaId,
+    @NotNull String evaluationCriteria,
+    @NotNull String feedbackText,
+    @NotNull int score) {}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/entity/EvaluationCriteriaEntity.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/entity/EvaluationCriteriaEntity.java
@@ -1,0 +1,49 @@
+package org.richardstallman.dvback.domain.evaluation.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.richardstallman.dvback.common.constant.CommonConstants.EvaluationCriteria;
+import org.richardstallman.dvback.domain.evaluation.entity.overall.OverallEvaluationEntity;
+import org.richardstallman.dvback.global.entity.BaseEntity;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Table(name = "evaluation_criteria")
+public class EvaluationCriteriaEntity extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "evaluation_criteria_seq")
+  @SequenceGenerator(
+      name = "evaluation_criteria_seq",
+      sequenceName = "evaluation_criteria_id_seq",
+      allocationSize = 1)
+  @Column(name = "evaluation_criteria_id")
+  private Long evaluationCriteriaId;
+
+  @NotNull(message = "Evaluation Criteria is required") @Enumerated(EnumType.STRING)
+  private EvaluationCriteria evaluationCriteriaName;
+
+  @NotNull(message = "Feedback Text is required") private String feedbackText;
+
+  @NotNull(message = "Score is required") private int score;
+
+  @ManyToOne(fetch = FetchType.EAGER)
+  @JoinColumn(name = "overall_evaluation_id")
+  private OverallEvaluationEntity overallEvaluation;
+}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/entity/answer/AnswerEvaluationEntity.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/entity/answer/AnswerEvaluationEntity.java
@@ -1,0 +1,49 @@
+package org.richardstallman.dvback.domain.evaluation.entity.answer;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.richardstallman.dvback.domain.evaluation.entity.overall.OverallEvaluationEntity;
+import org.richardstallman.dvback.domain.question.entity.QuestionEntity;
+import org.richardstallman.dvback.global.entity.BaseEntity;
+
+@Getter
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "ansewr_evaluations")
+public class AnswerEvaluationEntity extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "answer_evaluation_seq")
+  @SequenceGenerator(
+      name = "answer_evaluation_seq",
+      sequenceName = "answer_evaluation_id_seq",
+      allocationSize = 1)
+  @Column(name = "answer_evaluation_id")
+  private Long answerEvaluationId;
+
+  @ManyToOne(fetch = FetchType.EAGER)
+  @JoinColumn(name = "question_id", nullable = false)
+  private QuestionEntity question;
+
+  @JoinColumn(name = "answer_feedback_text", nullable = false)
+  private String answerFeedbackText;
+
+  @JoinColumn(name = "score", nullable = false)
+  private int score;
+
+  @ManyToOne(fetch = FetchType.EAGER)
+  @JoinColumn(name = "overall_evaluation_id")
+  private OverallEvaluationEntity overallEvaluation;
+}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/entity/answer/AnswerEvaluationEntity.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/entity/answer/AnswerEvaluationEntity.java
@@ -21,7 +21,7 @@ import org.richardstallman.dvback.global.entity.BaseEntity;
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
-@Table(name = "ansewr_evaluations")
+@Table(name = "answer_evaluations")
 public class AnswerEvaluationEntity extends BaseEntity {
 
   @Id
@@ -37,10 +37,10 @@ public class AnswerEvaluationEntity extends BaseEntity {
   @JoinColumn(name = "question_id", nullable = false)
   private QuestionEntity question;
 
-  @JoinColumn(name = "answer_feedback_text", nullable = false)
+  @Column(name = "answer_feedback_text", nullable = false)
   private String answerFeedbackText;
 
-  @JoinColumn(name = "score", nullable = false)
+  @Column(name = "score", nullable = false)
   private int score;
 
   @ManyToOne(fetch = FetchType.EAGER)

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/entity/overall/OverallEvaluationEntity.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/entity/overall/OverallEvaluationEntity.java
@@ -1,0 +1,36 @@
+package org.richardstallman.dvback.domain.evaluation.entity.overall;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.richardstallman.dvback.domain.interview.entity.InterviewEntity;
+import org.richardstallman.dvback.global.entity.BaseEntity;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Table(name = "overall_evaluations")
+public class OverallEvaluationEntity extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "overall_evaluation_seq")
+  @SequenceGenerator(
+      name = "overall_evaluation_seq",
+      sequenceName = "overall_evaluations_id_seq",
+      allocationSize = 1)
+  private Long overallEvaluationId;
+
+  @ManyToOne(fetch = FetchType.EAGER)
+  @JoinColumn(name = "interview_id", nullable = false)
+  private InterviewEntity interview;
+}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/repository/answer/AnswerEvaluationJpaRepository.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/repository/answer/AnswerEvaluationJpaRepository.java
@@ -1,0 +1,9 @@
+package org.richardstallman.dvback.domain.evaluation.repository.answer;
+
+import org.richardstallman.dvback.domain.evaluation.entity.answer.AnswerEvaluationEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AnswerEvaluationJpaRepository
+    extends JpaRepository<AnswerEvaluationEntity, Long> {}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/repository/answer/AnswerEvaluationRepository.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/repository/answer/AnswerEvaluationRepository.java
@@ -1,0 +1,11 @@
+package org.richardstallman.dvback.domain.evaluation.repository.answer;
+
+import java.util.List;
+import org.richardstallman.dvback.domain.evaluation.domain.answer.AnswerEvaluationDomain;
+
+public interface AnswerEvaluationRepository {
+
+  AnswerEvaluationDomain save(AnswerEvaluationDomain answerEvaluationDomain);
+
+  List<AnswerEvaluationDomain> saveAll(List<AnswerEvaluationDomain> answerEvaluationDomains);
+}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/repository/answer/AnswerEvaluationRepositoryImpl.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/repository/answer/AnswerEvaluationRepositoryImpl.java
@@ -1,0 +1,35 @@
+package org.richardstallman.dvback.domain.evaluation.repository.answer;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.richardstallman.dvback.domain.evaluation.converter.AnswerEvaluationConverter;
+import org.richardstallman.dvback.domain.evaluation.domain.answer.AnswerEvaluationDomain;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class AnswerEvaluationRepositoryImpl implements AnswerEvaluationRepository {
+
+  private final AnswerEvaluationConverter answerEvaluationConverter;
+  private final AnswerEvaluationJpaRepository answerEvaluationJpaRepository;
+
+  @Override
+  public AnswerEvaluationDomain save(AnswerEvaluationDomain answerEvaluationDomain) {
+    return answerEvaluationConverter.fromEntityToDomain(
+        answerEvaluationJpaRepository.save(
+            answerEvaluationConverter.fromDomainToEntity(answerEvaluationDomain)));
+  }
+
+  @Override
+  public List<AnswerEvaluationDomain> saveAll(
+      List<AnswerEvaluationDomain> answerEvaluationDomains) {
+    return answerEvaluationJpaRepository
+        .saveAll(
+            answerEvaluationDomains.stream()
+                .map(answerEvaluationConverter::fromDomainToEntity)
+                .toList())
+        .stream()
+        .map(answerEvaluationConverter::fromEntityToDomain)
+        .toList();
+  }
+}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/repository/criteria/EvaluationCriteriaJpaRepository.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/repository/criteria/EvaluationCriteriaJpaRepository.java
@@ -1,0 +1,14 @@
+package org.richardstallman.dvback.domain.evaluation.repository.criteria;
+
+import java.util.List;
+import org.richardstallman.dvback.domain.evaluation.entity.EvaluationCriteriaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EvaluationCriteriaJpaRepository
+    extends JpaRepository<EvaluationCriteriaEntity, Long> {
+
+  List<EvaluationCriteriaEntity> findByOverallEvaluationOverallEvaluationId(
+      Long overallEvaluationId);
+}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/repository/criteria/EvaluationCriteriaRepository.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/repository/criteria/EvaluationCriteriaRepository.java
@@ -1,0 +1,11 @@
+package org.richardstallman.dvback.domain.evaluation.repository.criteria;
+
+import java.util.List;
+import org.richardstallman.dvback.domain.evaluation.domain.EvaluationCriteriaDomain;
+
+public interface EvaluationCriteriaRepository {
+
+  EvaluationCriteriaDomain save(EvaluationCriteriaDomain evaluationCriteriaDomain);
+
+  List<EvaluationCriteriaDomain> findByOverallEvaluationId(Long overallEvaluationId);
+}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/repository/criteria/EvaluationCriteriaRepositoryImpl.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/repository/criteria/EvaluationCriteriaRepositoryImpl.java
@@ -1,0 +1,31 @@
+package org.richardstallman.dvback.domain.evaluation.repository.criteria;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.richardstallman.dvback.domain.evaluation.converter.EvaluationCriteriaConverter;
+import org.richardstallman.dvback.domain.evaluation.domain.EvaluationCriteriaDomain;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class EvaluationCriteriaRepositoryImpl implements EvaluationCriteriaRepository {
+
+  private final EvaluationCriteriaConverter evaluationCriteriaConverter;
+  private final EvaluationCriteriaJpaRepository evaluationCriteriaJpaRepository;
+
+  @Override
+  public EvaluationCriteriaDomain save(EvaluationCriteriaDomain evaluationCriteriaDomain) {
+    return evaluationCriteriaConverter.fromEntityToDomain(
+        evaluationCriteriaJpaRepository.save(
+            evaluationCriteriaConverter.fromDomainToEntity(evaluationCriteriaDomain)));
+  }
+
+  @Override
+  public List<EvaluationCriteriaDomain> findByOverallEvaluationId(Long overallEvaluationId) {
+    return evaluationCriteriaJpaRepository
+        .findByOverallEvaluationOverallEvaluationId(overallEvaluationId)
+        .stream()
+        .map(evaluationCriteriaConverter::fromEntityToDomain)
+        .toList();
+  }
+}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/repository/overall/OverallEvaluationJpaRepository.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/repository/overall/OverallEvaluationJpaRepository.java
@@ -1,0 +1,9 @@
+package org.richardstallman.dvback.domain.evaluation.repository.overall;
+
+import org.richardstallman.dvback.domain.evaluation.entity.overall.OverallEvaluationEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OverallEvaluationJpaRepository
+    extends JpaRepository<OverallEvaluationEntity, Long> {}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/repository/overall/OverallEvaluationRepository.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/repository/overall/OverallEvaluationRepository.java
@@ -1,0 +1,8 @@
+package org.richardstallman.dvback.domain.evaluation.repository.overall;
+
+import org.richardstallman.dvback.domain.evaluation.domain.overall.OverallEvaluationDomain;
+
+public interface OverallEvaluationRepository {
+
+  OverallEvaluationDomain save(OverallEvaluationDomain overallEvaluationDomain);
+}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/repository/overall/OverallEvaluationRepositoryImpl.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/repository/overall/OverallEvaluationRepositoryImpl.java
@@ -1,0 +1,25 @@
+package org.richardstallman.dvback.domain.evaluation.repository.overall;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.richardstallman.dvback.domain.evaluation.converter.OverallEvaluationConverter;
+import org.richardstallman.dvback.domain.evaluation.domain.overall.OverallEvaluationDomain;
+import org.richardstallman.dvback.domain.evaluation.entity.overall.OverallEvaluationEntity;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class OverallEvaluationRepositoryImpl implements OverallEvaluationRepository {
+
+  private final OverallEvaluationConverter overallEvaluationConverter;
+  private final OverallEvaluationJpaRepository overallEvaluationJpaRepository;
+
+  @Override
+  public OverallEvaluationDomain save(OverallEvaluationDomain overallEvaluationDomain) {
+    OverallEvaluationEntity savedEntity =
+        overallEvaluationJpaRepository.save(
+            overallEvaluationConverter.fromDomainToEntity(overallEvaluationDomain));
+    return overallEvaluationConverter.fromEntityToDomain(savedEntity);
+  }
+}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/service/EvaluationService.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/service/EvaluationService.java
@@ -1,0 +1,10 @@
+package org.richardstallman.dvback.domain.evaluation.service;
+
+import org.richardstallman.dvback.domain.evaluation.domain.overall.request.OverallEvaluationRequestDto;
+import org.richardstallman.dvback.domain.evaluation.domain.overall.response.OverallEvaluationResponseDto;
+
+public interface EvaluationService {
+
+  OverallEvaluationResponseDto getOverallEvaluation(
+      OverallEvaluationRequestDto overallEvaluationRequestDto);
+}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/service/EvaluationServiceImpl.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/service/EvaluationServiceImpl.java
@@ -1,0 +1,145 @@
+package org.richardstallman.dvback.domain.evaluation.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.richardstallman.dvback.client.python.PythonService;
+import org.richardstallman.dvback.common.constant.CommonConstants.EvaluationCriteria;
+import org.richardstallman.dvback.domain.answer.repository.AnswerRepository;
+import org.richardstallman.dvback.domain.evaluation.converter.AnswerEvaluationConverter;
+import org.richardstallman.dvback.domain.evaluation.converter.EvaluationCriteriaConverter;
+import org.richardstallman.dvback.domain.evaluation.converter.OverallEvaluationConverter;
+import org.richardstallman.dvback.domain.evaluation.domain.EvaluationCriteriaDomain;
+import org.richardstallman.dvback.domain.evaluation.domain.answer.AnswerEvaluationDomain;
+import org.richardstallman.dvback.domain.evaluation.domain.answer.response.AnswerEvaluationResponseDto;
+import org.richardstallman.dvback.domain.evaluation.domain.external.AnswerEvaluationExternalDomain;
+import org.richardstallman.dvback.domain.evaluation.domain.external.EvaluationCriteriaExternalDomain;
+import org.richardstallman.dvback.domain.evaluation.domain.external.OverallEvaluationExternalDomain;
+import org.richardstallman.dvback.domain.evaluation.domain.external.request.EvaluationExternalRequestDto;
+import org.richardstallman.dvback.domain.evaluation.domain.external.response.EvaluationExternalResponseDto;
+import org.richardstallman.dvback.domain.evaluation.domain.overall.OverallEvaluationDomain;
+import org.richardstallman.dvback.domain.evaluation.domain.overall.request.OverallEvaluationRequestDto;
+import org.richardstallman.dvback.domain.evaluation.domain.overall.response.OverallEvaluationResponseDto;
+import org.richardstallman.dvback.domain.evaluation.domain.response.EvaluationCriteriaResponseDto;
+import org.richardstallman.dvback.domain.evaluation.repository.answer.AnswerEvaluationRepository;
+import org.richardstallman.dvback.domain.evaluation.repository.criteria.EvaluationCriteriaRepository;
+import org.richardstallman.dvback.domain.evaluation.repository.overall.OverallEvaluationRepository;
+import org.richardstallman.dvback.domain.interview.domain.InterviewDomain;
+import org.richardstallman.dvback.domain.question.domain.QuestionDomain;
+import org.richardstallman.dvback.domain.question.repository.QuestionRepository;
+import org.richardstallman.dvback.global.advice.exceptions.ApiException;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EvaluationServiceImpl implements EvaluationService {
+
+  private final OverallEvaluationRepository overallEvaluationRepository;
+  private final OverallEvaluationConverter overallEvaluationConverter;
+  private final AnswerRepository answerRepository;
+  private final QuestionRepository questionRepository;
+  private final PythonService pythonService;
+  private final AnswerEvaluationConverter answerEvaluationConverter;
+  private final EvaluationCriteriaRepository evaluationCriteriaRepository;
+  private final AnswerEvaluationRepository answerEvaluationRepository;
+  private final EvaluationCriteriaConverter evaluationCriteriaConverter;
+
+  @Override
+  public OverallEvaluationResponseDto getOverallEvaluation(
+      OverallEvaluationRequestDto overallEvaluationRequestDto) {
+
+    List<QuestionDomain> questions =
+        questionRepository.findQuestionsByInterviewId(overallEvaluationRequestDto.interviewId());
+    List<String> questionTexts = new ArrayList<>();
+    List<String> answerTexts = new ArrayList<>();
+    for (QuestionDomain question : questions) {
+      questionTexts.add(question.getQuestionText());
+      answerTexts.add(answerRepository.findByQuestionId(question.getQuestionId()).getAnswerText());
+    }
+
+    InterviewDomain interviewDomain = questions.get(0).getInterviewDomain();
+
+    EvaluationExternalRequestDto evaluationExternalRequestDto =
+        new EvaluationExternalRequestDto(
+            "", // 파일 업로드 및 주소 저장 연결부 구현 후 작성하기
+            questionTexts,
+            answerTexts,
+            interviewDomain.getInterviewMode(),
+            interviewDomain.getInterviewType(),
+            interviewDomain.getInterviewMethod(),
+            interviewDomain.getJob().getJobName());
+
+    EvaluationExternalResponseDto evaluationExternalResponseDto =
+        pythonService.getOverallEvaluations(evaluationExternalRequestDto);
+
+    OverallEvaluationExternalDomain overallEvaluationExternalDomain =
+        evaluationExternalResponseDto.overallEvaluation();
+    List<AnswerEvaluationExternalDomain> answerEvaluationExternalDomains =
+        evaluationExternalResponseDto.answerEvaluations();
+
+    OverallEvaluationDomain createdOverallEvaluationDomain =
+        overallEvaluationRepository.save(
+            OverallEvaluationDomain.builder().interviewDomain(interviewDomain).build());
+
+    Map<EvaluationCriteria, EvaluationCriteriaExternalDomain> criteriaMap =
+        Map.of(
+            EvaluationCriteria.DEVELOPMENT_SKILL,
+            overallEvaluationExternalDomain.getDevelopmentSkill(),
+            EvaluationCriteria.GROWTH_POTENTIAL,
+            overallEvaluationExternalDomain.getGrowthPotential(),
+            EvaluationCriteria.TECHNICAL_DEPTH,
+            overallEvaluationExternalDomain.getTechnicalDepth(),
+            EvaluationCriteria.WORK_ATTITUDE,
+            overallEvaluationExternalDomain.getWorkAttitude());
+
+    criteriaMap.forEach(
+        (criteria, externalDomain) ->
+            evaluationCriteriaRepository.save(
+                EvaluationCriteriaDomain.builder()
+                    .evaluationCriteria(criteria)
+                    .overallEvaluationDomain(createdOverallEvaluationDomain)
+                    .feedbackText(externalDomain.getFeedbackText())
+                    .score(externalDomain.getScore())
+                    .build()));
+
+    List<AnswerEvaluationDomain> answerEvaluationDomains =
+        answerEvaluationRepository.saveAll(
+            answerEvaluationExternalDomains.stream()
+                .map(
+                    (e) ->
+                        answerEvaluationConverter.externalDomainToDomain(
+                            e,
+                            questionRepository
+                                .findById(e.getQuestionId())
+                                .orElseThrow(
+                                    () ->
+                                        new ApiException(
+                                            HttpStatus.NOT_FOUND,
+                                            e.getQuestionId() + " does not exist")),
+                            createdOverallEvaluationDomain))
+                .toList());
+
+    List<EvaluationCriteriaResponseDto> evaluationCriteriaResponseDtos =
+        evaluationCriteriaRepository
+            .findByOverallEvaluationId(createdOverallEvaluationDomain.getOverallEvaluationId())
+            .stream()
+            .map(evaluationCriteriaConverter::fromDomainToResponseDto)
+            .toList();
+    List<AnswerEvaluationResponseDto> answerEvaluationResponseDtos =
+        answerEvaluationDomains.stream()
+            .map(
+                (e) ->
+                    answerEvaluationConverter.fromDomainToResponseDto(
+                        e,
+                        answerRepository
+                            .findByQuestionId(e.getQuestionDomain().getQuestionId())
+                            .getAnswerText()))
+            .toList();
+    return overallEvaluationConverter.toResponseDto(
+        interviewDomain, evaluationCriteriaResponseDtos, answerEvaluationResponseDtos);
+  }
+}

--- a/src/main/java/org/richardstallman/dvback/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/org/richardstallman/dvback/domain/question/repository/QuestionRepository.java
@@ -1,11 +1,14 @@
 package org.richardstallman.dvback.domain.question.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.richardstallman.dvback.domain.question.domain.QuestionDomain;
 
 public interface QuestionRepository {
 
   QuestionDomain save(QuestionDomain questionDomain);
+
+  Optional<QuestionDomain> findById(Long questionId);
 
   List<QuestionDomain> findQuestionsByInterviewId(Long interviewId);
 }

--- a/src/main/java/org/richardstallman/dvback/domain/question/repository/QuestionRepositoryImpl.java
+++ b/src/main/java/org/richardstallman/dvback/domain/question/repository/QuestionRepositoryImpl.java
@@ -1,6 +1,7 @@
 package org.richardstallman.dvback.domain.question.repository;
 
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.richardstallman.dvback.domain.question.converter.QuestionConverter;
 import org.richardstallman.dvback.domain.question.domain.QuestionDomain;
@@ -17,6 +18,11 @@ public class QuestionRepositoryImpl implements QuestionRepository {
   public QuestionDomain save(QuestionDomain questionDomain) {
     return questionConverter.fromEntityToDomain(
         questionJpaRepository.save(questionConverter.fromDomainToEntity(questionDomain)));
+  }
+
+  @Override
+  public Optional<QuestionDomain> findById(Long questionId) {
+    return questionJpaRepository.findById(questionId).map(questionConverter::fromEntityToDomain);
   }
 
   @Override

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -18,6 +18,8 @@ spring:
 python:
   server:
     url: ${PYTHON_SERVER_URL}
+    question-path: /interview/questions
+    evaluation-path: /interview/evaluation
 
 cloud:
   aws:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -18,6 +18,8 @@ spring:
 python:
   server:
     url: ${PYTHON_SERVER_URL}
+    question-path: /interview/questions
+    evaluation-path: /interview/evaluation
 
 cloud:
   aws:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -18,6 +18,8 @@ spring:
 python:
   server:
     url: ${PYTHON_SERVER_URL}
+    question-path: /interview/questions
+    evaluation-path: /interview/evaluation
 
 cloud:
   aws:

--- a/src/test/java/org/richardstallman/dvback/domain/question/controller/QuestionControllerTest.java
+++ b/src/test/java/org/richardstallman/dvback/domain/question/controller/QuestionControllerTest.java
@@ -16,6 +16,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.richardstallman.dvback.DvBackApplication;
 import org.richardstallman.dvback.common.constant.CommonConstants.InterviewMethod;
 import org.richardstallman.dvback.common.constant.CommonConstants.InterviewMode;
 import org.richardstallman.dvback.common.constant.CommonConstants.InterviewStatus;
@@ -34,12 +35,14 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 @SpringBootTest
 @AutoConfigureRestDocs
 @AutoConfigureMockMvc
+@ContextConfiguration(classes = {DvBackApplication.class})
 public class QuestionControllerTest {
 
   @Autowired MockMvc mockMvc;

--- a/src/test/java/org/richardstallman/dvback/mock/question/FakeQuestionRepository.java
+++ b/src/test/java/org/richardstallman/dvback/mock/question/FakeQuestionRepository.java
@@ -3,6 +3,7 @@ package org.richardstallman.dvback.mock.question;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.extern.slf4j.Slf4j;
 import org.richardstallman.dvback.domain.question.domain.QuestionDomain;
@@ -32,6 +33,11 @@ public class FakeQuestionRepository implements QuestionRepository {
     data.removeIf(item -> Objects.equals(item.getQuestionId(), questionDomain.getQuestionId()));
     data.add(questionDomain);
     return questionDomain;
+  }
+
+  @Override
+  public Optional<QuestionDomain> findById(Long questionId) {
+    return data.stream().filter(item -> item.getQuestionId().equals(questionId)).findAny();
   }
 
   @Override


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치

DV-86-be-evaluation-implement

## 📚 작업한 내용
- 면접 평가 파이썬 요청 및 저장 로직 한 번에 구현
- CommonConstants에 있는 생성자 어노테이션으로 변경

## 📍 참고 사항

https://www.notion.so/_Joy-12f61cc3398380409d0af2c3b2e2dca4
- 파이썬 서버 돌아가야 작동!
- 노션 참고해보시면 리팩토링 고민을 좀 했는데 마감 기한이 얼마 남지 않아 전과 마찬가지로 일단 돌아가게 하고 다음으로 넘어가는 게 좋을 것 같아서 일단 올립니다!
  - 이번에 프론트랑 얘기해보고서 백에서 구현할 친구들이 생각보다 많이 생겨버려가지고.. 참고 부탁드려요!


## 📝 리뷰 중점 사안(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- 테스트코드 없는 이유: 파이썬 코드 테스트 오래걸릴 것 같아서 구현 모두 끝나면 시간 될 때 질문이랑 같이 만들어서 올리겠습니다.
  - postman 아주 아주 잘 되는 거 확인!(위 노션 페이지에 캡처 및 반환 값 있음)
- 코멘트 달겠습니다!