### PR TITLE
[DV-100] fix : python 전달값 맞춰서 다시 작성

### DIFF
--- a/src/main/java/org/richardstallman/dvback/common/constant/CommonConstants.java
+++ b/src/main/java/org/richardstallman/dvback/common/constant/CommonConstants.java
@@ -62,12 +62,20 @@ public class CommonConstants {
   @JsonFormat(shape = JsonFormat.Shape.STRING)
   public enum EvaluationCriteria {
     ANSWER("answer"),
-    DEVELOPMENT_SKILL("development_skill"),
+    JOB_FIT("jobFit"),
     GROWTH_POTENTIAL("growth_potential"),
     TECHNICAL_DEPTH("technical_depth"),
     WORK_ATTITUDE("work_attitude");
 
     private final String pythonFormat;
+  }
+
+  public enum AnswerEvaluationScore {
+    APPROPRIATE_RESPONSE,
+    LOGICAL_FLOW,
+    KEY_TERMS,
+    CONSISTENCY,
+    GRAMMATICAL_ERRORS
   }
 
   public enum PointTransactionType {

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/converter/AnswerEvaluationConverter.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/converter/AnswerEvaluationConverter.java
@@ -1,9 +1,11 @@
 package org.richardstallman.dvback.domain.evaluation.converter;
 
+import java.util.List;
 import org.richardstallman.dvback.domain.evaluation.domain.answer.AnswerEvaluationDomain;
 import org.richardstallman.dvback.domain.evaluation.domain.answer.response.AnswerEvaluationResponseDto;
 import org.richardstallman.dvback.domain.evaluation.domain.external.AnswerEvaluationExternalDomain;
 import org.richardstallman.dvback.domain.evaluation.domain.overall.OverallEvaluationDomain;
+import org.richardstallman.dvback.domain.evaluation.domain.response.AnswerEvaluationScoreResponseDto;
 import org.richardstallman.dvback.domain.evaluation.entity.answer.AnswerEvaluationEntity;
 import org.richardstallman.dvback.domain.question.converter.QuestionConverter;
 import org.richardstallman.dvback.domain.question.domain.QuestionDomain;
@@ -29,8 +31,9 @@ public class AnswerEvaluationConverter {
     return new AnswerEvaluationEntity(
         answerEvaluationDomain.getAnswerEvaluationId(),
         questionConverter.fromDomainToEntity(answerEvaluationDomain.getQuestionDomain()),
-        answerEvaluationDomain.getAnswerFeedbackText(),
-        answerEvaluationDomain.getScore(),
+        answerEvaluationDomain.getAnswerFeedbackStrength(),
+        answerEvaluationDomain.getAnswerFeedbackImprovement(),
+        answerEvaluationDomain.getAnswerFeedbackSuggestion(),
         overallEvaluationConverter.fromDomainToEntity(
             answerEvaluationDomain.getOverallEvaluationDomain()));
   }
@@ -39,8 +42,12 @@ public class AnswerEvaluationConverter {
     return AnswerEvaluationDomain.builder()
         .answerEvaluationId(answerEvaluationEntity.getAnswerEvaluationId())
         .questionDomain(questionConverter.fromEntityToDomain(answerEvaluationEntity.getQuestion()))
-        .answerFeedbackText(answerEvaluationEntity.getAnswerFeedbackText())
-        .score(answerEvaluationEntity.getScore())
+        .answerFeedbackStrength(answerEvaluationEntity.getAnswerFeedbackStrength())
+        .answerFeedbackImprovement(answerEvaluationEntity.getAnswerFeedbackImprovement())
+        .answerFeedbackSuggestion(answerEvaluationEntity.getAnswerFeedbackSuggestion())
+        .overallEvaluationDomain(
+            overallEvaluationConverter.fromEntityToDomain(
+                answerEvaluationEntity.getOverallEvaluation()))
         .build();
   }
 
@@ -50,19 +57,33 @@ public class AnswerEvaluationConverter {
       OverallEvaluationDomain overallEvaluationDomain) {
     return AnswerEvaluationDomain.builder()
         .questionDomain(questionDomain)
-        .answerFeedbackText(answerEvaluationExternalDomain.getFeedbackText())
-        .score(answerEvaluationExternalDomain.getScore())
+        .answerFeedbackStrength(
+            answerEvaluationExternalDomain
+                .getAnswerEvaluationFeedbackExternalDomain()
+                .getStrength())
+        .answerFeedbackImprovement(
+            answerEvaluationExternalDomain
+                .getAnswerEvaluationFeedbackExternalDomain()
+                .getImprovement())
+        .answerFeedbackSuggestion(
+            answerEvaluationExternalDomain
+                .getAnswerEvaluationFeedbackExternalDomain()
+                .getSuggestion())
         .overallEvaluationDomain(overallEvaluationDomain)
         .build();
   }
 
   public AnswerEvaluationResponseDto fromDomainToResponseDto(
-      AnswerEvaluationDomain answerEvaluationDomain, String answerText) {
+      AnswerEvaluationDomain answerEvaluationDomain,
+      String answerText,
+      List<AnswerEvaluationScoreResponseDto> answerEvaluationScoreResponseDtos) {
     return new AnswerEvaluationResponseDto(
         answerEvaluationDomain.getAnswerEvaluationId(),
         answerEvaluationDomain.getQuestionDomain().getQuestionText(),
         answerText,
-        answerEvaluationDomain.getAnswerFeedbackText(),
-        answerEvaluationDomain.getScore());
+        answerEvaluationDomain.getAnswerFeedbackStrength(),
+        answerEvaluationDomain.getAnswerFeedbackImprovement(),
+        answerEvaluationDomain.getAnswerFeedbackSuggestion(),
+        answerEvaluationScoreResponseDtos);
   }
 }

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/converter/AnswerEvaluationScoreConverter.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/converter/AnswerEvaluationScoreConverter.java
@@ -1,0 +1,52 @@
+package org.richardstallman.dvback.domain.evaluation.converter;
+
+import org.richardstallman.dvback.domain.evaluation.domain.answer.AnswerEvaluationScoreDomain;
+import org.richardstallman.dvback.domain.evaluation.domain.response.AnswerEvaluationScoreResponseDto;
+import org.richardstallman.dvback.domain.evaluation.entity.answer.AnswerEvaluationScoreEntity;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AnswerEvaluationScoreConverter {
+
+  private final AnswerEvaluationConverter answerEvaluationConverter;
+
+  @Autowired
+  public AnswerEvaluationScoreConverter(@Lazy AnswerEvaluationConverter answerEvaluationConverter) {
+    this.answerEvaluationConverter = answerEvaluationConverter;
+  }
+
+  public AnswerEvaluationScoreDomain fromEntityToDomain(
+      AnswerEvaluationScoreEntity answerEvaluationScoreEntity) {
+    return AnswerEvaluationScoreDomain.builder()
+        .answerEvaluationScoreId(answerEvaluationScoreEntity.getAnswerEvaluationScoreId())
+        .answerEvaluationScoreName(answerEvaluationScoreEntity.getAnswerEvaluationScoreName())
+        .score(answerEvaluationScoreEntity.getScore())
+        .rationale(answerEvaluationScoreEntity.getRationale())
+        .answerEvaluationDomain(
+            answerEvaluationConverter.fromEntityToDomain(
+                answerEvaluationScoreEntity.getAnswerEvaluationEntity()))
+        .build();
+  }
+
+  public AnswerEvaluationScoreEntity fromDomainToEntity(
+      AnswerEvaluationScoreDomain answerEvaluationScoreDomain) {
+    return new AnswerEvaluationScoreEntity(
+        answerEvaluationScoreDomain.getAnswerEvaluationScoreId(),
+        answerEvaluationScoreDomain.getAnswerEvaluationScoreName(),
+        answerEvaluationScoreDomain.getScore(),
+        answerEvaluationScoreDomain.getRationale(),
+        answerEvaluationConverter.fromDomainToEntity(
+            answerEvaluationScoreDomain.getAnswerEvaluationDomain()));
+  }
+
+  public AnswerEvaluationScoreResponseDto fromDomainToResponseDto(
+      AnswerEvaluationScoreDomain answerEvaluationScoreDomain) {
+    return new AnswerEvaluationScoreResponseDto(
+        answerEvaluationScoreDomain.getAnswerEvaluationScoreId(),
+        answerEvaluationScoreDomain.getAnswerEvaluationScoreName().name(),
+        answerEvaluationScoreDomain.getScore(),
+        answerEvaluationScoreDomain.getRationale());
+  }
+}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/answer/AnswerEvaluationDomain.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/answer/AnswerEvaluationDomain.java
@@ -11,7 +11,8 @@ public class AnswerEvaluationDomain {
 
   private final Long answerEvaluationId;
   private final QuestionDomain questionDomain;
-  private final String answerFeedbackText;
-  private final int score;
+  private final String answerFeedbackStrength;
+  private final String answerFeedbackImprovement;
+  private final String answerFeedbackSuggestion;
   private final OverallEvaluationDomain overallEvaluationDomain;
 }

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/answer/AnswerEvaluationScoreDomain.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/answer/AnswerEvaluationScoreDomain.java
@@ -1,0 +1,16 @@
+package org.richardstallman.dvback.domain.evaluation.domain.answer;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.richardstallman.dvback.common.constant.CommonConstants.AnswerEvaluationScore;
+
+@Builder
+@Getter
+public class AnswerEvaluationScoreDomain {
+
+  private Long answerEvaluationScoreId;
+  private AnswerEvaluationScore answerEvaluationScoreName;
+  private int score;
+  private String rationale;
+  private AnswerEvaluationDomain answerEvaluationDomain;
+}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/answer/response/AnswerEvaluationResponseDto.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/answer/response/AnswerEvaluationResponseDto.java
@@ -1,10 +1,14 @@
 package org.richardstallman.dvback.domain.evaluation.domain.answer.response;
 
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import org.richardstallman.dvback.domain.evaluation.domain.response.AnswerEvaluationScoreResponseDto;
 
 public record AnswerEvaluationResponseDto(
     @NotNull Long answerEvaluationId,
     @NotNull String questionText,
     @NotNull String answerText,
-    @NotNull String answerFeedbackText,
-    @NotNull int score) {}
+    @NotNull String answerFeedbackStrength,
+    @NotNull String answerFeedbackImprovement,
+    @NotNull String answerFeedbackSuggestion,
+    @NotNull List<AnswerEvaluationScoreResponseDto> answerEvaluationScores) {}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/external/AnswerEvaluationCriteriaExternalDomain.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/external/AnswerEvaluationCriteriaExternalDomain.java
@@ -8,11 +8,11 @@ import lombok.Getter;
 @Getter
 @Builder
 @AllArgsConstructor
-public class EvaluationCriteriaExternalDomain {
+public class AnswerEvaluationCriteriaExternalDomain {
 
   @JsonProperty("score")
   private int score;
 
-  @JsonProperty("feedback")
-  private String feedbackText;
+  @JsonProperty("rationale")
+  private String rationale;
 }

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/external/AnswerEvaluationExternalDomain.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/external/AnswerEvaluationExternalDomain.java
@@ -9,12 +9,12 @@ import lombok.Getter;
 @Getter
 public class AnswerEvaluationExternalDomain {
 
-  @NotNull @JsonProperty("feedback_text")
-  String feedbackText;
+  @NotNull @JsonProperty("feedback")
+  AnswerEvaluationFeedbackExternalDomain answerEvaluationFeedbackExternalDomain;
 
   @NotNull @JsonProperty("question_id")
   long questionId;
 
-  @NotNull @JsonProperty("score")
-  int score;
+  @NotNull @JsonProperty("scores")
+  AnswerEvaluationScoreExternalDomain answerEvaluationScoreExternalDomain;
 }

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/external/AnswerEvaluationFeedbackExternalDomain.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/external/AnswerEvaluationFeedbackExternalDomain.java
@@ -1,0 +1,21 @@
+package org.richardstallman.dvback.domain.evaluation.domain.external;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class AnswerEvaluationFeedbackExternalDomain {
+
+  @JsonProperty("strengths")
+  private String strength;
+
+  @JsonProperty("improvement")
+  private String improvement;
+
+  @JsonProperty("suggestion")
+  private String suggestion;
+}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/external/AnswerEvaluationScoreExternalDomain.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/external/AnswerEvaluationScoreExternalDomain.java
@@ -1,0 +1,27 @@
+package org.richardstallman.dvback.domain.evaluation.domain.external;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class AnswerEvaluationScoreExternalDomain {
+
+  @JsonProperty("appropriate_response")
+  private AnswerEvaluationCriteriaExternalDomain appropriateResponse;
+
+  @JsonProperty("logical_flow")
+  private AnswerEvaluationCriteriaExternalDomain logicalFlow;
+
+  @JsonProperty("key_terms")
+  private AnswerEvaluationCriteriaExternalDomain keyTerms;
+
+  @JsonProperty("consistency")
+  private AnswerEvaluationCriteriaExternalDomain consistency;
+
+  @JsonProperty("grammatical_errors")
+  private AnswerEvaluationCriteriaExternalDomain grammaticalErrors;
+}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/external/OverallEvaluationExternalDomain.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/external/OverallEvaluationExternalDomain.java
@@ -10,8 +10,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public class OverallEvaluationExternalDomain {
 
-  @JsonProperty("development_skill")
-  private EvaluationCriteriaExternalDomain developmentSkill;
+  @JsonProperty("job_fit")
+  private EvaluationCriteriaExternalDomain jobFit;
 
   @JsonProperty("growth_potential")
   private EvaluationCriteriaExternalDomain growthPotential;

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/external/request/EvaluationExternalRequestDto.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/external/request/EvaluationExternalRequestDto.java
@@ -1,6 +1,7 @@
 package org.richardstallman.dvback.domain.evaluation.domain.external.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import org.richardstallman.dvback.common.constant.CommonConstants.InterviewMethod;
 import org.richardstallman.dvback.common.constant.CommonConstants.InterviewMode;
@@ -8,12 +9,12 @@ import org.richardstallman.dvback.common.constant.CommonConstants.InterviewType;
 
 public record EvaluationExternalRequestDto(
     @JsonProperty("cover_letter") String coverLetterS3Url,
-    @JsonProperty("questions") List<String> questions,
-    @JsonProperty("answers") List<String> answers,
-    @JsonProperty("interview_mode") String interviewMode,
-    @JsonProperty("interview_type") String interviewType,
-    @JsonProperty("interview_method") String interviewMethod,
-    @JsonProperty("job_role") String jobName) {
+    @JsonProperty("questions") @NotNull List<String> questions,
+    @JsonProperty("answers") @NotNull List<String> answers,
+    @JsonProperty("interview_mode") @NotNull String interviewMode,
+    @JsonProperty("interview_type") @NotNull String interviewType,
+    @JsonProperty("interview_method") @NotNull String interviewMethod,
+    @JsonProperty("job_role") @NotNull String jobName) {
 
   public EvaluationExternalRequestDto(
       String coverLetterS3Url,

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/response/AnswerEvaluationScoreResponseDto.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/domain/response/AnswerEvaluationScoreResponseDto.java
@@ -1,0 +1,9 @@
+package org.richardstallman.dvback.domain.evaluation.domain.response;
+
+import jakarta.validation.constraints.NotNull;
+
+public record AnswerEvaluationScoreResponseDto(
+    @NotNull Long answerEvaluationScoreId,
+    @NotNull String answerEvaluationScoreName,
+    @NotNull int score,
+    @NotNull String rationale) {}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/entity/answer/AnswerEvaluationEntity.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/entity/answer/AnswerEvaluationEntity.java
@@ -37,11 +37,14 @@ public class AnswerEvaluationEntity extends BaseEntity {
   @JoinColumn(name = "question_id", nullable = false)
   private QuestionEntity question;
 
-  @Column(name = "answer_feedback_text", nullable = false)
-  private String answerFeedbackText;
+  @Column(name = "answer_feedback_strength", nullable = false)
+  private String answerFeedbackStrength;
 
-  @Column(name = "score", nullable = false)
-  private int score;
+  @Column(name = "answer_feedback_improvement", nullable = false)
+  private String answerFeedbackImprovement;
+
+  @Column(name = "answer_feedback_suggestion", nullable = false)
+  private String answerFeedbackSuggestion;
 
   @ManyToOne(fetch = FetchType.EAGER)
   @JoinColumn(name = "overall_evaluation_id")

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/entity/answer/AnswerEvaluationScoreEntity.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/entity/answer/AnswerEvaluationScoreEntity.java
@@ -1,0 +1,48 @@
+package org.richardstallman.dvback.domain.evaluation.entity.answer;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.richardstallman.dvback.common.constant.CommonConstants.AnswerEvaluationScore;
+import org.richardstallman.dvback.global.entity.BaseEntity;
+
+@Getter
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "answer_evaluation_scores")
+public class AnswerEvaluationScoreEntity extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "answer_evaluation_score_seq")
+  @SequenceGenerator(
+      name = "answer_evaluation_score_seq",
+      sequenceName = "answer_evaluation_score_id_seq",
+      allocationSize = 1)
+  @Column(name = "answer_evaluation_score_id")
+  private Long answerEvaluationScoreId;
+
+  @NotNull(message = "Answer Evaluation Score is required") @Enumerated(EnumType.STRING)
+  private AnswerEvaluationScore answerEvaluationScoreName;
+
+  @NotNull(message = "Score is required") private int score;
+
+  @NotNull(message = "Rationale is required") private String rationale;
+
+  @ManyToOne(fetch = FetchType.EAGER)
+  @JoinColumn(name = "answer_evaluation_id")
+  private AnswerEvaluationEntity answerEvaluationEntity;
+}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/repository/answer/score/AnswerEvaluationScoreJpaRepository.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/repository/answer/score/AnswerEvaluationScoreJpaRepository.java
@@ -1,0 +1,14 @@
+package org.richardstallman.dvback.domain.evaluation.repository.answer.score;
+
+import java.util.List;
+import org.richardstallman.dvback.domain.evaluation.entity.answer.AnswerEvaluationScoreEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AnswerEvaluationScoreJpaRepository
+    extends JpaRepository<AnswerEvaluationScoreEntity, Long> {
+
+  List<AnswerEvaluationScoreEntity> findByAnswerEvaluationEntityAnswerEvaluationId(
+      Long answerEvaluationId);
+}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/repository/answer/score/AnswerEvaluationScoreRepository.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/repository/answer/score/AnswerEvaluationScoreRepository.java
@@ -1,0 +1,14 @@
+package org.richardstallman.dvback.domain.evaluation.repository.answer.score;
+
+import java.util.List;
+import org.richardstallman.dvback.domain.evaluation.domain.answer.AnswerEvaluationScoreDomain;
+
+public interface AnswerEvaluationScoreRepository {
+
+  AnswerEvaluationScoreDomain save(AnswerEvaluationScoreDomain answerEvaluationScoreDomain);
+
+  List<AnswerEvaluationScoreDomain> saveAll(
+      List<AnswerEvaluationScoreDomain> answerEvaluationScoreDomains);
+
+  List<AnswerEvaluationScoreDomain> findByAnswerEvaluationId(Long answerEvaluationId);
+}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/repository/answer/score/AnswerEvaluationScoreRepositoryImpl.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/repository/answer/score/AnswerEvaluationScoreRepositoryImpl.java
@@ -1,0 +1,44 @@
+package org.richardstallman.dvback.domain.evaluation.repository.answer.score;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.richardstallman.dvback.domain.evaluation.converter.AnswerEvaluationScoreConverter;
+import org.richardstallman.dvback.domain.evaluation.domain.answer.AnswerEvaluationScoreDomain;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class AnswerEvaluationScoreRepositoryImpl implements AnswerEvaluationScoreRepository {
+
+  private final AnswerEvaluationScoreConverter answerEvaluationScoreConverter;
+  private final AnswerEvaluationScoreJpaRepository answerEvaluationScoreJpaRepository;
+
+  @Override
+  public AnswerEvaluationScoreDomain save(AnswerEvaluationScoreDomain answerEvaluationScoreDomain) {
+    return answerEvaluationScoreConverter.fromEntityToDomain(
+        answerEvaluationScoreJpaRepository.save(
+            answerEvaluationScoreConverter.fromDomainToEntity(answerEvaluationScoreDomain)));
+  }
+
+  @Override
+  public List<AnswerEvaluationScoreDomain> saveAll(
+      List<AnswerEvaluationScoreDomain> answerEvaluationScoreDomains) {
+    return answerEvaluationScoreJpaRepository
+        .saveAll(
+            answerEvaluationScoreDomains.stream()
+                .map(answerEvaluationScoreConverter::fromDomainToEntity)
+                .toList())
+        .stream()
+        .map(answerEvaluationScoreConverter::fromEntityToDomain)
+        .toList();
+  }
+
+  @Override
+  public List<AnswerEvaluationScoreDomain> findByAnswerEvaluationId(Long answerEvaluationId) {
+    return answerEvaluationScoreJpaRepository
+        .findByAnswerEvaluationEntityAnswerEvaluationId(answerEvaluationId)
+        .stream()
+        .map(answerEvaluationScoreConverter::fromEntityToDomain)
+        .toList();
+  }
+}

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/repository/criteria/EvaluationCriteriaRepository.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/repository/criteria/EvaluationCriteriaRepository.java
@@ -7,5 +7,7 @@ public interface EvaluationCriteriaRepository {
 
   EvaluationCriteriaDomain save(EvaluationCriteriaDomain evaluationCriteriaDomain);
 
+  List<EvaluationCriteriaDomain> saveAll(List<EvaluationCriteriaDomain> evaluationCriteriaDomains);
+
   List<EvaluationCriteriaDomain> findByOverallEvaluationId(Long overallEvaluationId);
 }

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/repository/criteria/EvaluationCriteriaRepositoryImpl.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/repository/criteria/EvaluationCriteriaRepositoryImpl.java
@@ -21,6 +21,19 @@ public class EvaluationCriteriaRepositoryImpl implements EvaluationCriteriaRepos
   }
 
   @Override
+  public List<EvaluationCriteriaDomain> saveAll(
+      List<EvaluationCriteriaDomain> evaluationCriteriaDomains) {
+    return evaluationCriteriaJpaRepository
+        .saveAll(
+            evaluationCriteriaDomains.stream()
+                .map(evaluationCriteriaConverter::fromDomainToEntity)
+                .toList())
+        .stream()
+        .map(evaluationCriteriaConverter::fromEntityToDomain)
+        .toList();
+  }
+
+  @Override
   public List<EvaluationCriteriaDomain> findByOverallEvaluationId(Long overallEvaluationId) {
     return evaluationCriteriaJpaRepository
         .findByOverallEvaluationOverallEvaluationId(overallEvaluationId)


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치

- DV-100-be-evaluation-connect-with-python

## 📚 작업한 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- 파이썬 전달값 맞춰서 다시 작성
- 면접 평가  필드: development_skill -> job_fit 이거 하나만 변경
- 답변 평가 필드 : 
### 이전 답변 평가 필드
``` json
{
  "answer_evaluations": [
    {
      "feedback_text": "string",
      "question_id": 0,
      "score": 0
    }
  ]
}
```
### 이후 답변 평가 필드
``` json
{
  "answer_evaluations": [
    {
      "question_id": 1,
      "scores": {
        "appropriate_response": { "score": integer, "rationale": "Detailed rationale for score" },
        "logical_flow": { "score": integer, "rationale": "Detailed rationale for score" },
        "key_terms": { "score": integer, "rationale": "Detailed rationale for score" },
        "consistency": { "score": integer, "rationale": "Detailed rationale for score" },
        "grammatical_errors": { "score": integer, "rationale": "Detailed rationale for score" }
      },
      "feedback": {
        "strengths": "Detailed feedback on strengths",
        "improvement": "Detailed feedback on areas for improvement",
        "suggestion": "Detailed feedback on suggestions"
      }
    },
    ...
  ]
}
```


## 📍 참고 사항

<!-- 참고할 사항이 있다면 적어주세요. -->
- 바꿀 부분이 많아서 생각보다 오래 걸렸습니다.. ㅠㅠ 파이썬 테스트코드 작성해서 올려보려했는데 다음 로직 작성이 우선인 것 같아 일단 올립니다!
- 로컬에서 파이썬 돌아가고 있어야 돕니다!
- 이전 평가 로직도 메소드로 다 빼서 리팩토링해봤습니다!

