### PR TITLE
feat : 질문 요청 / 정보 저장 로직 제대로 돌아가도록 구현 및 정리

### DIFF
--- a/src/main/java/org/richardstallman/dvback/domain/question/converter/QuestionConverter.java
+++ b/src/main/java/org/richardstallman/dvback/domain/question/converter/QuestionConverter.java
@@ -77,8 +77,10 @@ public class QuestionConverter {
       Boolean hasNext) {
     return new QuestionResponseDto(
         interviewQuestionResponseDto,
-        firstQuestionDomain.getQuestionText(),
+        firstQuestionDomain == null ? null : firstQuestionDomain.getQuestionId(),
+        firstQuestionDomain == null ? null : firstQuestionDomain.getQuestionText(),
         secondQuestionDomain == null ? null : secondQuestionDomain.getQuestionId(),
+        secondQuestionDomain == null ? null : secondQuestionDomain.getQuestionText(),
         hasNext);
   }
 

--- a/src/main/java/org/richardstallman/dvback/domain/question/domain/request/QuestionNextRequestDto.java
+++ b/src/main/java/org/richardstallman/dvback/domain/question/domain/request/QuestionNextRequestDto.java
@@ -5,5 +5,6 @@ import org.richardstallman.dvback.domain.answer.domain.request.AnswerPreviousReq
 
 public record QuestionNextRequestDto(
     @NotNull Long interviewId,
-    @NotNull Long questionId,
+    @NotNull Long answerQuestionId,
+    Long nextQuestionId,
     @NotNull AnswerPreviousRequestDto answer) {}

--- a/src/main/java/org/richardstallman/dvback/domain/question/domain/response/QuestionResponseDto.java
+++ b/src/main/java/org/richardstallman/dvback/domain/question/domain/response/QuestionResponseDto.java
@@ -5,6 +5,8 @@ import org.richardstallman.dvback.domain.interview.domain.response.InterviewQues
 
 public record QuestionResponseDto(
     @NotNull InterviewQuestionResponseDto interview,
-    @NotNull String questionText,
+    @NotNull Long currentQuestionId,
+    @NotNull String currentQuestionText,
     Long nextQuestionId,
+    String nextQuestionText,
     @NotNull Boolean hasNext) {}

--- a/src/main/java/org/richardstallman/dvback/domain/question/service/QuestionServiceImpl.java
+++ b/src/main/java/org/richardstallman/dvback/domain/question/service/QuestionServiceImpl.java
@@ -123,8 +123,15 @@ public class QuestionServiceImpl implements QuestionService {
         questionRepository.findQuestionsByInterviewId(questionNextRequestDto.interviewId());
 
     QuestionDomain previousQuestion =
-        findQuestionById(questions, questionNextRequestDto.questionId());
-    QuestionDomain nextQuestion = findNextQuestion(questions, previousQuestion);
+        findQuestionById(questions, questionNextRequestDto.answerQuestionId());
+    QuestionDomain currentQuestion =
+        questionNextRequestDto.nextQuestionId() == null
+            ? null
+            : findQuestionById(questions, questionNextRequestDto.nextQuestionId());
+    QuestionDomain nextQuestion =
+        questionNextRequestDto.nextQuestionId() == null
+            ? null
+            : findNextQuestion(questions, currentQuestion);
     boolean hasNext = nextQuestion != null;
 
     answerRepository.save(
@@ -132,7 +139,7 @@ public class QuestionServiceImpl implements QuestionService {
             questionNextRequestDto.answer(), previousQuestion));
 
     return questionConverter.fromQuestionExternalDomainToQuestionResponseDto(
-        previousQuestion,
+        currentQuestion,
         interviewConverter.fromDomainToQuestionResponseDto(previousQuestion.getInterviewDomain()),
         nextQuestion,
         hasNext);
@@ -157,6 +164,10 @@ public class QuestionServiceImpl implements QuestionService {
         .findFirst()
         .orElseThrow(
             () -> new ApiException(HttpStatus.BAD_REQUEST, questionId + " does not exist"));
+  }
+
+  private QuestionDomain findNextQuestionById(Long questionId) {
+    return questionRepository.findById(questionId).orElse(null);
   }
 
   private QuestionDomain findNextQuestion(

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -48,8 +48,8 @@ spring:
 python:
   server:
     url: ${PYTHON_SERVER_URL}
-    question-path: /interview/questions
-    evaluation-path: /interview/evaluation
+    question-path: /interview/questions-test
+    evaluation-path: /interview/evaluation-test
 
 cloud:
   aws:

--- a/src/test/java/org/richardstallman/dvback/domain/question/controller/QuestionControllerTest.java
+++ b/src/test/java/org/richardstallman/dvback/domain/question/controller/QuestionControllerTest.java
@@ -75,7 +75,7 @@ public class QuestionControllerTest {
             InterviewType.TECHNICAL,
             InterviewMethod.CHAT,
             InterviewMode.GENERAL,
-            null,
+            new ArrayList<>(),
             1L);
     String content = objectMapper.writeValueAsString(questionInitialRequestDto);
 
@@ -97,8 +97,10 @@ public class QuestionControllerTest {
                         .jobNameKorean("백엔드")
                         .jobDescription("백엔드 직무입니다.")
                         .build()),
+                1L,
                 "스타크래프트를 처음으로 접한 경험을 통해 어떻게 최고를 목표로 삼고 성취했는지 이야기해보세요.",
                 2L,
+                "스타크래프트를 처음으로 접한 경험을 통해 어떻게 최고를 목표로 삼고 성취했는지 이야기해보세요2.",
                 true));
     ResultActions resultActions =
         mockMvc.perform(
@@ -123,7 +125,7 @@ public class QuestionControllerTest {
         .andExpect(jsonPath("data.interview.job.jobNameKorean").value("백엔드"))
         .andExpect(jsonPath("data.interview.job.jobDescription").value("백엔드 직무입니다."))
         .andExpect(
-            jsonPath("data.questionText")
+            jsonPath("data.currentQuestionText")
                 .value("스타크래프트를 처음으로 접한 경험을 통해 어떻게 최고를 목표로 삼고 성취했는지 이야기해보세요."))
         .andExpect(jsonPath("data.nextQuestionId").value(2L))
         .andExpect(jsonPath("data.hasNext").value(true));
@@ -158,7 +160,7 @@ public class QuestionControllerTest {
                             .type(JsonFieldType.STRING)
                             .description("면접 모드"),
                         fieldWithPath("files")
-                            .type(JsonFieldType.NULL)
+                            .type(JsonFieldType.ARRAY)
                             .description("모의 면접이므로 파일 정보 없어야 함."),
                         fieldWithPath("jobId").type(JsonFieldType.NUMBER).description("직무 식별자"))
                     .responseFields(
@@ -194,12 +196,18 @@ public class QuestionControllerTest {
                         fieldWithPath("data.interview.job.jobDescription")
                             .type(JsonFieldType.STRING)
                             .description("직무 설명"),
-                        fieldWithPath("data.questionText")
+                        fieldWithPath("data.currentQuestionId")
+                            .type(JsonFieldType.NUMBER)
+                            .description("현재 질문 식별자"),
+                        fieldWithPath("data.currentQuestionText")
                             .type(JsonFieldType.STRING)
-                            .description("질문 내용"),
+                            .description("현재 질문 내용"),
                         fieldWithPath("data.nextQuestionId")
                             .type(JsonFieldType.NUMBER)
                             .description("다음 질문 식별자"),
+                        fieldWithPath("data.nextQuestionText")
+                            .type(JsonFieldType.STRING)
+                            .description("다음 질문 내용"),
                         fieldWithPath("data.hasNext")
                             .type(JsonFieldType.BOOLEAN)
                             .description("다음 질문 존재 여부"))
@@ -247,8 +255,10 @@ public class QuestionControllerTest {
                         .jobNameKorean("백엔드")
                         .jobDescription("백엔드 직무입니다.")
                         .build()),
+                1L,
                 "스타크래프트를 처음으로 접한 경험을 통해 어떻게 최고를 목표로 삼고 성취했는지 이야기해보세요.",
                 2L,
+                "다음 질문입니다.",
                 true));
     ResultActions resultActions =
         mockMvc.perform(
@@ -273,7 +283,7 @@ public class QuestionControllerTest {
         .andExpect(jsonPath("data.interview.job.jobNameKorean").value("백엔드"))
         .andExpect(jsonPath("data.interview.job.jobDescription").value("백엔드 직무입니다."))
         .andExpect(
-            jsonPath("data.questionText")
+            jsonPath("data.currentQuestionText")
                 .value("스타크래프트를 처음으로 접한 경험을 통해 어떻게 최고를 목표로 삼고 성취했는지 이야기해보세요."))
         .andExpect(jsonPath("data.nextQuestionId").value(2L))
         .andExpect(jsonPath("data.hasNext").value(true));
@@ -347,12 +357,18 @@ public class QuestionControllerTest {
                         fieldWithPath("data.interview.job.jobDescription")
                             .type(JsonFieldType.STRING)
                             .description("직무 설명"),
-                        fieldWithPath("data.questionText")
+                        fieldWithPath("data.currentQuestionId")
+                            .type(JsonFieldType.NUMBER)
+                            .description("현재 질문 식별자"),
+                        fieldWithPath("data.currentQuestionText")
                             .type(JsonFieldType.STRING)
-                            .description("질문 내용"),
+                            .description("현재 질문 내용"),
                         fieldWithPath("data.nextQuestionId")
                             .type(JsonFieldType.NUMBER)
                             .description("다음 질문 식별자"),
+                        fieldWithPath("data.nextQuestionText")
+                            .type(JsonFieldType.STRING)
+                            .description("다음 질문 내용"),
                         fieldWithPath("data.hasNext")
                             .type(JsonFieldType.BOOLEAN)
                             .description("다음 질문 존재 여부"))
@@ -366,7 +382,7 @@ public class QuestionControllerTest {
     AnswerPreviousRequestDto answerPreviousRequestDto =
         new AnswerPreviousRequestDto("답변입니다.", "", "");
     QuestionNextRequestDto questionNextRequestDto =
-        new QuestionNextRequestDto(1L, 2L, answerPreviousRequestDto);
+        new QuestionNextRequestDto(1L, 1L, 2L, answerPreviousRequestDto);
     String content = objectMapper.writeValueAsString(questionNextRequestDto);
 
     when(questionService.getNextQuestion(any()))
@@ -385,8 +401,10 @@ public class QuestionControllerTest {
                         .jobNameKorean("백엔드")
                         .jobDescription("백엔드 직무입니다.")
                         .build()),
+                1L,
                 "리액트와 스프링 간의 연동 경험을 설명해 주세요.",
-                3L,
+                2L,
+                "협업 과정에서 가장 힘들었던 일이 있다면 무엇이었나요?",
                 true));
 
     // when
@@ -411,8 +429,8 @@ public class QuestionControllerTest {
         .andExpect(jsonPath("data.interview.job.jobName").value("BACK_END"))
         .andExpect(jsonPath("data.interview.job.jobNameKorean").value("백엔드"))
         .andExpect(jsonPath("data.interview.job.jobDescription").value("백엔드 직무입니다."))
-        .andExpect(jsonPath("data.questionText").value("리액트와 스프링 간의 연동 경험을 설명해 주세요."))
-        .andExpect(jsonPath("data.nextQuestionId").value(3L))
+        .andExpect(jsonPath("data.currentQuestionText").value("리액트와 스프링 간의 연동 경험을 설명해 주세요."))
+        .andExpect(jsonPath("data.nextQuestionId").value(2L))
         .andExpect(jsonPath("data.hasNext").value(true));
 
     // restdocs
@@ -429,9 +447,6 @@ public class QuestionControllerTest {
                         fieldWithPath("interviewId")
                             .type(JsonFieldType.NUMBER)
                             .description("면접 식별자"),
-                        fieldWithPath("questionId")
-                            .type(JsonFieldType.NUMBER)
-                            .description("요청 질문 식별자"),
                         fieldWithPath("answer.s3AudioUrl")
                             .type(JsonFieldType.STRING)
                             .description("답변 오디오 s3 저장 url"),
@@ -440,7 +455,13 @@ public class QuestionControllerTest {
                             .description("답변 비디오 s3 저장 url"),
                         fieldWithPath("answer.answerText")
                             .type(JsonFieldType.STRING)
-                            .description("이전 질문에 대한 답변"))
+                            .description("이전 질문에 대한 답변"),
+                        fieldWithPath("answerQuestionId")
+                            .type(JsonFieldType.NUMBER)
+                            .description("전달되는 답변에 대한 질문 식별자"),
+                        fieldWithPath("nextQuestionId")
+                            .type(JsonFieldType.NUMBER)
+                            .description("반환해줘야 하는 다음 질문 식별자"))
                     .responseFields(
                         fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
                         fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
@@ -474,12 +495,18 @@ public class QuestionControllerTest {
                         fieldWithPath("data.interview.job.jobDescription")
                             .type(JsonFieldType.STRING)
                             .description("직무 설명"),
-                        fieldWithPath("data.questionText")
+                        fieldWithPath("data.currentQuestionId")
+                            .type(JsonFieldType.NUMBER)
+                            .description("현재 질문 식별자"),
+                        fieldWithPath("data.currentQuestionText")
                             .type(JsonFieldType.STRING)
-                            .description("질문 내용"),
+                            .description("현재 질문 내용"),
                         fieldWithPath("data.nextQuestionId")
                             .type(JsonFieldType.NUMBER)
                             .description("다음 질문 식별자"),
+                        fieldWithPath("data.nextQuestionText")
+                            .type(JsonFieldType.STRING)
+                            .description("다음 질문 내용"),
                         fieldWithPath("data.hasNext")
                             .type(JsonFieldType.BOOLEAN)
                             .description("다음 질문 존재 여부"))


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치

- DV-149-be-update-question-logic

## 📚 작업한 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- answer 모두 저장되도록 수정(전체 질문 / 답변 로직 후 첫 답변 저장 안 되는 이슈 해결)
- 프론트 / 백 연결 원활하도록 전달값 수정
- POST /question/next-question && POST /question/initial-question
둘 다 currentQuestionId / currentQuestionText / nextQuestionId / nextQuestionText 반환하도록 수정
- 비용 절감 위해 적용했던 python endpoint local에서만 적용되도록 yml 수정
- 빌드 / 실행 / swagger 테스트 완료

## 📝 로직 설명
[프론트 전달 위한 payload 설명](https://www.notion.so/payload-13c61cc3398380dcb025f49e88d22201)
[로직 설명](https://www.notion.so/13c61cc3398380299687ed0746944262)

