### PR TITLE
DV-150-be-interview-evaluation-list-logic-update

### DIFF
--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/controller/EvaluationController.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/controller/EvaluationController.java
@@ -6,7 +6,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.richardstallman.dvback.common.DvApiResponse;
 import org.richardstallman.dvback.domain.evaluation.domain.overall.request.OverallEvaluationRequestDto;
 import org.richardstallman.dvback.domain.evaluation.domain.overall.response.OverallEvaluationResponseDto;
-import org.richardstallman.dvback.domain.evaluation.domain.overall.response.OverallEvaluationUserInfoListResponseDto;
 import org.richardstallman.dvback.domain.evaluation.service.EvaluationService;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -32,14 +31,6 @@ public class EvaluationController {
     final OverallEvaluationResponseDto overallEvaluationResponseDto =
         evaluationService.getOverallEvaluation(overallEvaluationRequestDto);
     return ResponseEntity.ok(DvApiResponse.of(overallEvaluationResponseDto));
-  }
-
-  @GetMapping
-  public ResponseEntity<DvApiResponse<OverallEvaluationUserInfoListResponseDto>>
-      getOverallEvaluation(@AuthenticationPrincipal final Long userId) {
-    final OverallEvaluationUserInfoListResponseDto overallEvaluationUserInfoListResponseDto =
-        evaluationService.getOverallEvaluationListByUserId(userId);
-    return ResponseEntity.ok(DvApiResponse.of(overallEvaluationUserInfoListResponseDto));
   }
 
   @GetMapping("/{interviewId}")

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/converter/OverallEvaluationConverter.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/converter/OverallEvaluationConverter.java
@@ -1,7 +1,6 @@
 package org.richardstallman.dvback.domain.evaluation.converter;
 
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import org.richardstallman.dvback.domain.evaluation.domain.answer.response.AnswerEvaluationResponseDto;
 import org.richardstallman.dvback.domain.evaluation.domain.overall.OverallEvaluationDomain;
 import org.richardstallman.dvback.domain.evaluation.domain.overall.response.OverallEvaluationResponseDto;
@@ -12,13 +11,17 @@ import org.richardstallman.dvback.domain.file.domain.response.FileResponseDto;
 import org.richardstallman.dvback.domain.interview.converter.InterviewConverter;
 import org.richardstallman.dvback.domain.interview.domain.InterviewDomain;
 import org.richardstallman.dvback.domain.interview.domain.response.InterviewEvaluationResponseDto;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
 @Component
-@RequiredArgsConstructor
 public class OverallEvaluationConverter {
 
   private final InterviewConverter interviewConverter;
+
+  public OverallEvaluationConverter(@Lazy InterviewConverter interviewConverter) {
+    this.interviewConverter = interviewConverter;
+  }
 
   public OverallEvaluationEntity fromDomainToEntity(
       OverallEvaluationDomain overallEvaluationDomain) {

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/entity/overall/OverallEvaluationEntity.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/entity/overall/OverallEvaluationEntity.java
@@ -1,12 +1,11 @@
 package org.richardstallman.dvback.domain.evaluation.entity.overall;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
@@ -30,7 +29,7 @@ public class OverallEvaluationEntity extends BaseEntity {
       allocationSize = 1)
   private Long overallEvaluationId;
 
-  @ManyToOne(fetch = FetchType.EAGER)
+  @OneToOne
   @JoinColumn(name = "interview_id", nullable = false)
   private InterviewEntity interview;
 }

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/service/EvaluationService.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/service/EvaluationService.java
@@ -2,14 +2,11 @@ package org.richardstallman.dvback.domain.evaluation.service;
 
 import org.richardstallman.dvback.domain.evaluation.domain.overall.request.OverallEvaluationRequestDto;
 import org.richardstallman.dvback.domain.evaluation.domain.overall.response.OverallEvaluationResponseDto;
-import org.richardstallman.dvback.domain.evaluation.domain.overall.response.OverallEvaluationUserInfoListResponseDto;
 
 public interface EvaluationService {
 
   OverallEvaluationResponseDto getOverallEvaluation(
       OverallEvaluationRequestDto overallEvaluationRequestDto);
-
-  OverallEvaluationUserInfoListResponseDto getOverallEvaluationListByUserId(Long userId);
 
   OverallEvaluationResponseDto getOverallEvaluationByInterviewId(Long interviewId);
 }

--- a/src/main/java/org/richardstallman/dvback/domain/evaluation/service/EvaluationServiceImpl.java
+++ b/src/main/java/org/richardstallman/dvback/domain/evaluation/service/EvaluationServiceImpl.java
@@ -31,7 +31,6 @@ import org.richardstallman.dvback.domain.evaluation.domain.external.response.Eva
 import org.richardstallman.dvback.domain.evaluation.domain.overall.OverallEvaluationDomain;
 import org.richardstallman.dvback.domain.evaluation.domain.overall.request.OverallEvaluationRequestDto;
 import org.richardstallman.dvback.domain.evaluation.domain.overall.response.OverallEvaluationResponseDto;
-import org.richardstallman.dvback.domain.evaluation.domain.overall.response.OverallEvaluationUserInfoListResponseDto;
 import org.richardstallman.dvback.domain.evaluation.domain.response.EvaluationCriteriaResponseDto;
 import org.richardstallman.dvback.domain.evaluation.repository.answer.AnswerEvaluationRepository;
 import org.richardstallman.dvback.domain.evaluation.repository.answer.score.AnswerEvaluationScoreRepository;
@@ -40,7 +39,6 @@ import org.richardstallman.dvback.domain.evaluation.repository.overall.OverallEv
 import org.richardstallman.dvback.domain.file.converter.CoverLetterConverter;
 import org.richardstallman.dvback.domain.file.domain.response.FileResponseDto;
 import org.richardstallman.dvback.domain.interview.domain.InterviewDomain;
-import org.richardstallman.dvback.domain.interview.domain.response.InterviewEvaluationResponseDto;
 import org.richardstallman.dvback.domain.interview.service.InterviewService;
 import org.richardstallman.dvback.domain.question.converter.QuestionConverter;
 import org.richardstallman.dvback.domain.question.domain.QuestionDomain;
@@ -97,16 +95,6 @@ public class EvaluationServiceImpl implements EvaluationService {
   }
 
   @Override
-  public OverallEvaluationUserInfoListResponseDto getOverallEvaluationListByUserId(Long userId) {
-    List<InterviewEvaluationResponseDto> interviewEvaluationResponseDtos =
-        interviewService.getInterviewsByUserId(userId);
-    return new OverallEvaluationUserInfoListResponseDto(
-        interviewEvaluationResponseDtos.stream()
-            .map(overallEvaluationConverter::toUserInfoResponseDto)
-            .toList());
-  }
-
-  @Override
   public OverallEvaluationResponseDto getOverallEvaluationByInterviewId(Long interviewId) {
     InterviewDomain interviewDomain = interviewService.getInterviewById(interviewId);
 
@@ -131,7 +119,7 @@ public class EvaluationServiceImpl implements EvaluationService {
         questions.stream()
             .map(questionConverter::fromDomainToEvaluationExternalRequestDto)
             .toList();
-    System.out.println("BB");
+
     List<EvaluationExternalAnswerRequestDto> answerTexts =
         questions.stream()
             .map(

--- a/src/main/java/org/richardstallman/dvback/domain/interview/controller/InterviewController.java
+++ b/src/main/java/org/richardstallman/dvback/domain/interview/controller/InterviewController.java
@@ -6,11 +6,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.richardstallman.dvback.common.DvApiResponse;
 import org.richardstallman.dvback.domain.interview.domain.request.InterviewCreateRequestDto;
 import org.richardstallman.dvback.domain.interview.domain.response.InterviewCreateResponseDto;
+import org.richardstallman.dvback.domain.interview.domain.response.InterviewEvaluationListResponseDto;
+import org.richardstallman.dvback.domain.interview.domain.response.InterviewListResponseDto;
 import org.richardstallman.dvback.domain.interview.service.InterviewService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -36,5 +39,21 @@ public class InterviewController {
 
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(DvApiResponse.of(interviewCreateResponseDto));
+  }
+
+  @GetMapping("/evaluation")
+  public ResponseEntity<DvApiResponse<InterviewEvaluationListResponseDto>>
+      getInterviewsForEvaluation(@AuthenticationPrincipal final Long userId) {
+    final InterviewEvaluationListResponseDto interviewEvaluationListResponseDto =
+        interviewService.getInterviewsByUserIdForEvaluation(userId);
+    return ResponseEntity.ok(DvApiResponse.of(interviewEvaluationListResponseDto));
+  }
+
+  @GetMapping
+  public ResponseEntity<DvApiResponse<InterviewListResponseDto>> getInterviews(
+      @AuthenticationPrincipal final Long userId) {
+    final InterviewListResponseDto interviewListResponseDto =
+        interviewService.getInterviewsByUserId(userId);
+    return ResponseEntity.ok(DvApiResponse.of(interviewListResponseDto));
   }
 }

--- a/src/main/java/org/richardstallman/dvback/domain/interview/converter/InterviewConverter.java
+++ b/src/main/java/org/richardstallman/dvback/domain/interview/converter/InterviewConverter.java
@@ -4,6 +4,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.richardstallman.dvback.common.constant.CommonConstants.InterviewMode;
 import org.richardstallman.dvback.common.constant.CommonConstants.InterviewStatus;
+import org.richardstallman.dvback.domain.evaluation.converter.OverallEvaluationConverter;
 import org.richardstallman.dvback.domain.file.converter.CoverLetterConverter;
 import org.richardstallman.dvback.domain.file.domain.CoverLetterDomain;
 import org.richardstallman.dvback.domain.file.domain.response.FileResponseDto;
@@ -28,6 +29,7 @@ public class InterviewConverter {
   private final JobConverter jobConverter;
   private final CoverLetterConverter coverLetterConverter;
   private final UserConverter userConverter;
+  private final OverallEvaluationConverter overallEvaluationConverter;
 
   public InterviewEntity fromDomainToEntity(InterviewDomain interviewDomain) {
     return new InterviewEntity(
@@ -41,7 +43,11 @@ public class InterviewConverter {
         jobConverter.toEntity(interviewDomain.getJob()),
         interviewDomain.getInterviewMode() == InterviewMode.REAL
             ? coverLetterConverter.fromDomainToEntity(interviewDomain.getCoverLetter())
-            : null);
+            : null,
+        interviewDomain.getOverallEvaluationDomain() == null
+            ? null
+            : overallEvaluationConverter.fromDomainToEntity(
+                interviewDomain.getOverallEvaluationDomain()));
   }
 
   public InterviewEntity fromDomainToEntityWhenCreate(InterviewDomain interviewDomain) {
@@ -72,6 +78,11 @@ public class InterviewConverter {
             interviewEntity.getInterviewMode() == InterviewMode.REAL
                 ? coverLetterConverter.fromEntityToDomain(interviewEntity.getCoverLetter())
                 : null)
+        .overallEvaluationDomain(
+            interviewEntity.getOverallEvaluation() == null
+                ? null
+                : overallEvaluationConverter.fromEntityToDomain(
+                    interviewEntity.getOverallEvaluation()))
         .build();
   }
 

--- a/src/main/java/org/richardstallman/dvback/domain/interview/domain/InterviewDomain.java
+++ b/src/main/java/org/richardstallman/dvback/domain/interview/domain/InterviewDomain.java
@@ -6,6 +6,7 @@ import org.richardstallman.dvback.common.constant.CommonConstants.InterviewMetho
 import org.richardstallman.dvback.common.constant.CommonConstants.InterviewMode;
 import org.richardstallman.dvback.common.constant.CommonConstants.InterviewStatus;
 import org.richardstallman.dvback.common.constant.CommonConstants.InterviewType;
+import org.richardstallman.dvback.domain.evaluation.domain.overall.OverallEvaluationDomain;
 import org.richardstallman.dvback.domain.file.domain.CoverLetterDomain;
 import org.richardstallman.dvback.domain.job.domain.JobDomain;
 import org.richardstallman.dvback.domain.user.domain.UserDomain;
@@ -23,6 +24,7 @@ public class InterviewDomain {
   private InterviewMode interviewMode;
   private JobDomain job;
   private CoverLetterDomain coverLetter;
+  private OverallEvaluationDomain overallEvaluationDomain;
 
   //  private Long resumeId;
   //  private Long portfolioId;

--- a/src/main/java/org/richardstallman/dvback/domain/interview/domain/response/InterviewEvaluationListResponseDto.java
+++ b/src/main/java/org/richardstallman/dvback/domain/interview/domain/response/InterviewEvaluationListResponseDto.java
@@ -1,0 +1,7 @@
+package org.richardstallman.dvback.domain.interview.domain.response;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record InterviewEvaluationListResponseDto(
+    @NotNull List<InterviewEvaluationResponseDto> interviews) {}

--- a/src/main/java/org/richardstallman/dvback/domain/interview/domain/response/InterviewEvaluationResponseDto.java
+++ b/src/main/java/org/richardstallman/dvback/domain/interview/domain/response/InterviewEvaluationResponseDto.java
@@ -1,3 +1,6 @@
 package org.richardstallman.dvback.domain.interview.domain.response;
 
-public record InterviewEvaluationResponseDto(Long interviewId, String interviewTitle) {}
+import jakarta.validation.constraints.NotNull;
+
+public record InterviewEvaluationResponseDto(
+    @NotNull Long interviewId, @NotNull String interviewTitle) {}

--- a/src/main/java/org/richardstallman/dvback/domain/interview/domain/response/InterviewListResponseDto.java
+++ b/src/main/java/org/richardstallman/dvback/domain/interview/domain/response/InterviewListResponseDto.java
@@ -1,0 +1,6 @@
+package org.richardstallman.dvback.domain.interview.domain.response;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record InterviewListResponseDto(@NotNull List<InterviewCreateResponseDto> interviews) {}

--- a/src/main/java/org/richardstallman/dvback/domain/interview/entity/InterviewEntity.java
+++ b/src/main/java/org/richardstallman/dvback/domain/interview/entity/InterviewEntity.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
@@ -19,6 +20,7 @@ import org.richardstallman.dvback.common.constant.CommonConstants.InterviewMetho
 import org.richardstallman.dvback.common.constant.CommonConstants.InterviewMode;
 import org.richardstallman.dvback.common.constant.CommonConstants.InterviewStatus;
 import org.richardstallman.dvback.common.constant.CommonConstants.InterviewType;
+import org.richardstallman.dvback.domain.evaluation.entity.overall.OverallEvaluationEntity;
 import org.richardstallman.dvback.domain.file.entity.CoverLetterEntity;
 import org.richardstallman.dvback.domain.job.entity.JobEntity;
 import org.richardstallman.dvback.domain.user.entity.UserEntity;
@@ -61,6 +63,9 @@ public class InterviewEntity extends BaseEntity {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "cover_letter_id")
   private CoverLetterEntity coverLetter;
+
+  @OneToOne(mappedBy = "interview", fetch = FetchType.LAZY)
+  private OverallEvaluationEntity overallEvaluation;
 
   public InterviewEntity(
       UserEntity user,

--- a/src/main/java/org/richardstallman/dvback/domain/interview/repository/InterviewJpaRepository.java
+++ b/src/main/java/org/richardstallman/dvback/domain/interview/repository/InterviewJpaRepository.java
@@ -2,11 +2,20 @@ package org.richardstallman.dvback.domain.interview.repository;
 
 import java.util.List;
 import org.richardstallman.dvback.domain.interview.entity.InterviewEntity;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface InterviewJpaRepository extends JpaRepository<InterviewEntity, Long> {
 
-  List<InterviewEntity> findByUserId(Long userId);
+  List<InterviewEntity> findByUserIdOrderByInterviewIdDesc(Long userId);
+
+  @EntityGraph(attributePaths = {"overallEvaluation"})
+  @Query(
+      "SELECT i FROM InterviewEntity i WHERE i.user.id = :userId AND i.overallEvaluation IS NOT NULL ORDER BY i.interviewId DESC")
+  List<InterviewEntity> findByUserIdWithEvaluationsOrderByInterviewIdDesc(
+      @Param("userId") Long userId);
 }

--- a/src/main/java/org/richardstallman/dvback/domain/interview/repository/InterviewRepository.java
+++ b/src/main/java/org/richardstallman/dvback/domain/interview/repository/InterviewRepository.java
@@ -10,4 +10,6 @@ public interface InterviewRepository {
   InterviewDomain findById(Long interviewId);
 
   List<InterviewDomain> findInterviewsByUserId(Long userId);
+
+  List<InterviewDomain> findInterviewsByUserIdWithEvaluation(Long userId);
 }

--- a/src/main/java/org/richardstallman/dvback/domain/interview/repository/InterviewRepositoryImpl.java
+++ b/src/main/java/org/richardstallman/dvback/domain/interview/repository/InterviewRepositoryImpl.java
@@ -28,7 +28,14 @@ public class InterviewRepositoryImpl implements InterviewRepository {
 
   @Override
   public List<InterviewDomain> findInterviewsByUserId(Long userId) {
-    return interviewJpaRepository.findByUserId(userId).stream()
+    return interviewJpaRepository.findByUserIdOrderByInterviewIdDesc(userId).stream()
+        .map(interviewConverter::fromEntityToDomain)
+        .toList();
+  }
+
+  @Override
+  public List<InterviewDomain> findInterviewsByUserIdWithEvaluation(Long userId) {
+    return interviewJpaRepository.findByUserIdWithEvaluationsOrderByInterviewIdDesc(userId).stream()
         .map(interviewConverter::fromEntityToDomain)
         .toList();
   }

--- a/src/main/java/org/richardstallman/dvback/domain/interview/service/InterviewService.java
+++ b/src/main/java/org/richardstallman/dvback/domain/interview/service/InterviewService.java
@@ -1,17 +1,19 @@
 package org.richardstallman.dvback.domain.interview.service;
 
-import java.util.List;
 import org.richardstallman.dvback.domain.interview.domain.InterviewDomain;
 import org.richardstallman.dvback.domain.interview.domain.request.InterviewCreateRequestDto;
 import org.richardstallman.dvback.domain.interview.domain.response.InterviewCreateResponseDto;
-import org.richardstallman.dvback.domain.interview.domain.response.InterviewEvaluationResponseDto;
+import org.richardstallman.dvback.domain.interview.domain.response.InterviewEvaluationListResponseDto;
+import org.richardstallman.dvback.domain.interview.domain.response.InterviewListResponseDto;
 
 public interface InterviewService {
 
   InterviewCreateResponseDto createInterview(
       InterviewCreateRequestDto interviewCreateRequestDto, Long userId);
 
-  List<InterviewEvaluationResponseDto> getInterviewsByUserId(Long userId);
+  InterviewListResponseDto getInterviewsByUserId(Long userId);
 
   InterviewDomain getInterviewById(Long interviewId);
+
+  InterviewEvaluationListResponseDto getInterviewsByUserIdForEvaluation(Long userId);
 }

--- a/src/main/java/org/richardstallman/dvback/domain/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/org/richardstallman/dvback/domain/interview/service/InterviewServiceImpl.java
@@ -73,8 +73,6 @@ public class InterviewServiceImpl implements InterviewService {
 
   @Override
   public InterviewListResponseDto getInterviewsByUserId(Long userId) {
-    //    List<FileResponseDto> fileResponseDtos = new ArrayList<>();
-    //    if(interview)
     List<InterviewCreateResponseDto> interviewCreateResponseDtos =
         interviewRepository.findInterviewsByUserId(userId).stream()
             .map(
@@ -85,7 +83,6 @@ public class InterviewServiceImpl implements InterviewService {
     return new InterviewListResponseDto(interviewCreateResponseDtos);
   }
 
-  //  private InterviewCreateResponseDto fromInterviewDomainToCreateResponseDto
   private List<FileResponseDto> getFiles(InterviewDomain interviewDomain) {
     List<FileResponseDto> fileResponseDtos = new ArrayList<>();
     if (interviewDomain.getInterviewMode() == InterviewMode.REAL) {

--- a/src/test/java/org/richardstallman/dvback/domain/evaluation/controller/EvaluationControllerTest.java
+++ b/src/test/java/org/richardstallman/dvback/domain/evaluation/controller/EvaluationControllerTest.java
@@ -25,8 +25,6 @@ import org.richardstallman.dvback.common.constant.CommonConstants.InterviewStatu
 import org.richardstallman.dvback.common.constant.CommonConstants.InterviewType;
 import org.richardstallman.dvback.domain.evaluation.domain.answer.response.AnswerEvaluationResponseDto;
 import org.richardstallman.dvback.domain.evaluation.domain.overall.response.OverallEvaluationResponseDto;
-import org.richardstallman.dvback.domain.evaluation.domain.overall.response.OverallEvaluationUserInfoListResponseDto;
-import org.richardstallman.dvback.domain.evaluation.domain.overall.response.OverallEvaluationUserInfoResponseDto;
 import org.richardstallman.dvback.domain.evaluation.domain.response.AnswerEvaluationScoreResponseDto;
 import org.richardstallman.dvback.domain.evaluation.domain.response.EvaluationCriteriaResponseDto;
 import org.richardstallman.dvback.domain.evaluation.service.EvaluationService;
@@ -53,66 +51,6 @@ public class EvaluationControllerTest {
   @Autowired JwtUtil jwtUtil;
 
   @MockBean private EvaluationService evaluationService;
-
-  @Test
-  @DisplayName("마이페이지 - 면접 평가 조회 위한 면접 정보 목록(면접 식별자, 면접 제목) 조회 - 성공")
-  void getMyPageInterviewInfoListForInterviewEvaluation() throws Exception {
-    // given
-    Long userId = 1L;
-    List<OverallEvaluationUserInfoResponseDto> overallEvaluationUserInfoResponseDtos =
-        new ArrayList<>();
-    overallEvaluationUserInfoResponseDtos.add(
-        new OverallEvaluationUserInfoResponseDto("241101_백엔드_모의", 1L));
-    overallEvaluationUserInfoResponseDtos.add(
-        new OverallEvaluationUserInfoResponseDto("241103_프론트엔드_실전", 3L));
-    overallEvaluationUserInfoResponseDtos.add(
-        new OverallEvaluationUserInfoResponseDto("241105_클라우드_실전", 5L));
-    overallEvaluationUserInfoResponseDtos.add(
-        new OverallEvaluationUserInfoResponseDto("241105_인공지능_모의", 6L));
-
-    String accessToken = jwtUtil.generateAccessToken(userId);
-    MockCookie authCookie = new MockCookie("access_token", accessToken);
-
-    when(evaluationService.getOverallEvaluationListByUserId(userId))
-        .thenReturn(
-            new OverallEvaluationUserInfoListResponseDto(overallEvaluationUserInfoResponseDtos));
-
-    // when
-    ResultActions resultActions =
-        mockMvc.perform(
-            get("/evaluation").cookie(authCookie).contentType(MediaType.APPLICATION_JSON));
-
-    // then
-    resultActions
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("code").value(200))
-        .andExpect(jsonPath("message").value("SUCCESS"))
-        .andExpect(jsonPath("data.evaluationInfos[0].interviewTitle").value("241101_백엔드_모의"))
-        .andExpect(jsonPath("data.evaluationInfos[0].interviewId").value(1))
-        .andExpect(jsonPath("data.evaluationInfos[1].interviewTitle").value("241103_프론트엔드_실전"))
-        .andExpect(jsonPath("data.evaluationInfos[1].interviewId").value(3))
-        .andExpect(jsonPath("data.evaluationInfos[3].interviewTitle").value("241105_인공지능_모의"))
-        .andExpect(jsonPath("data.evaluationInfos[3].interviewId").value(6))
-        .andExpect(jsonPath("data.evaluationInfos[2].interviewTitle").value("241105_클라우드_실전"))
-        .andExpect(jsonPath("data.evaluationInfos[2].interviewId").value(5));
-
-    // restdocs
-    resultActions.andDo(
-        document(
-            "마이페이지 - 면접 평가 조회 위한 면접 정보 목록(면접 식별자, 면접 제목) 조회 - 성공",
-            preprocessResponse(prettyPrint()),
-            resource(
-                ResourceSnippetParameters.builder()
-                    .tag("Evaluation API")
-                    .summary("평가 API")
-                    .responseFields(
-                        fieldWithPath("code").description("응답 코드"),
-                        fieldWithPath("message").description("응답 메시지"),
-                        fieldWithPath("data.evaluationInfos[0].interviewTitle")
-                            .description("면접 제목"),
-                        fieldWithPath("data.evaluationInfos[0].interviewId").description("면접 식별자"))
-                    .build())));
-  }
 
   @Test
   @DisplayName("마이페이지 - 면접 평가 조회 - 성공")

--- a/src/test/java/org/richardstallman/dvback/mock/interview/FakeInterviewRepository.java
+++ b/src/test/java/org/richardstallman/dvback/mock/interview/FakeInterviewRepository.java
@@ -49,4 +49,11 @@ public class FakeInterviewRepository implements InterviewRepository {
         .filter(item -> Objects.equals(item.getUserDomain().getId(), userId))
         .toList();
   }
+
+  @Override
+  public List<InterviewDomain> findInterviewsByUserIdWithEvaluation(Long userId) {
+    return data.stream()
+        .filter(item -> Objects.nonNull(item.getOverallEvaluationDomain()))
+        .toList();
+  }
 }


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치

- DV-150-be-interview-evaluation-list-logic-update

## 📚 작업한 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- 면접 조회 관련 endpoint 변경 및 추가
- Lian이 전에 말해준대로 시간 역순으로 확실하게 들어오도록 JpaRepository단에서 처리

