### PR TITLE
Dv-162 회원 예외처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,9 @@ dependencies {
     // swaggerUI
     swaggerUI 'org.webjars:swagger-ui:4.11.1'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+    // BadWordFilter (비속어 필터링 라이브러리)
+    implementation 'io.github.vaneproject:badwordfiltering:1.0.0'
 }
 
 configurations.all {

--- a/src/main/java/org/richardstallman/dvback/client/s3/config/S3Config.java
+++ b/src/main/java/org/richardstallman/dvback/client/s3/config/S3Config.java
@@ -8,6 +8,7 @@ import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
@@ -22,6 +23,15 @@ public class S3Config {
   public AwsCredentialsProvider awsCredentialsProvider() {
     AwsCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
     return StaticCredentialsProvider.create(awsCredentials);
+  }
+
+  @Bean
+  public S3Client s3Client() {
+    return S3Client.builder()
+        .region(Region.AP_NORTHEAST_2)
+        .credentialsProvider(
+            StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
+        .build();
   }
 
   @Bean

--- a/src/main/java/org/richardstallman/dvback/client/s3/service/S3Service.java
+++ b/src/main/java/org/richardstallman/dvback/client/s3/service/S3Service.java
@@ -1,9 +1,11 @@
 package org.richardstallman.dvback.client.s3.service;
 
 import jakarta.annotation.Nullable;
+import java.io.IOException;
 import java.util.Map;
 import org.richardstallman.dvback.common.constant.CommonConstants.FileType;
 import org.richardstallman.dvback.domain.file.domain.response.PreSignedUrlResponseDto;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface S3Service {
 
@@ -20,4 +22,6 @@ public interface S3Service {
 
   PreSignedUrlResponseDto getDownloadURLForInterview(
       String filePath, Long userId, @Nullable Long interviewId);
+
+  String uploadImageToS3(MultipartFile image, FileType fileType, Long userId) throws IOException;
 }

--- a/src/main/java/org/richardstallman/dvback/domain/user/controller/UserController.java
+++ b/src/main/java/org/richardstallman/dvback/domain/user/controller/UserController.java
@@ -83,9 +83,9 @@ public class UserController {
   }
 
   @GetMapping("/profile-image")
-  public ResponseEntity<DvApiResponse<Boolean>> getProfileImage(@AuthenticationPrincipal Long userId) {
-
-    return ResponseEntity.ok(DvApiResponse.of(true));
+  public ResponseEntity<DvApiResponse<String>> getProfileImage(@AuthenticationPrincipal Long userId) {
+    String profileImageUrl = userService.getProfileImage(userId);
+    return ResponseEntity.ok(DvApiResponse.of(profileImageUrl));
   }
 
   @GetMapping("/validate-username")

--- a/src/main/java/org/richardstallman/dvback/domain/user/controller/UserController.java
+++ b/src/main/java/org/richardstallman/dvback/domain/user/controller/UserController.java
@@ -33,7 +33,6 @@ public class UserController {
   public ResponseEntity<?> logout(HttpServletRequest request, HttpServletResponse response) {
     String refreshToken =
         tokenService.getTokenFromCookies(request.getCookies(), JwtUtil.REFRESH_TOKEN);
-    log.info("refreshToken: {}", refreshToken);
     userService.logout(response, refreshToken);
 
     return ResponseEntity.ok("Logged out successfully");
@@ -81,5 +80,21 @@ public class UserController {
     }
 
     return ResponseEntity.ok(DvApiResponse.of(true));
+  }
+
+  @GetMapping("/profile-image")
+  public ResponseEntity<DvApiResponse<Boolean>> getProfileImage(@AuthenticationPrincipal Long userId) {
+
+    return ResponseEntity.ok(DvApiResponse.of(true));
+  }
+
+  @GetMapping("/validate-username")
+  public ResponseEntity<DvApiResponse<Boolean>> validateUsername(@RequestParam("username") String username) {
+
+    if (userService.existsByUsername(username)) {
+      return ResponseEntity.ok(DvApiResponse.of(true));
+    }
+
+    return ResponseEntity.ok(DvApiResponse.of(false));
   }
 }

--- a/src/main/java/org/richardstallman/dvback/domain/user/controller/UserController.java
+++ b/src/main/java/org/richardstallman/dvback/domain/user/controller/UserController.java
@@ -43,7 +43,7 @@ public class UserController {
     return ResponseEntity.ok("Logged out successfully");
   }
 
-  @PostMapping("/info")
+  @PostMapping(value = "/info", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<DvApiResponse<UserResponseDto>> updateUserInfo(
       @AuthenticationPrincipal Long userId,
       @RequestPart("userInfo") @Valid final UserRequestDto userRequestDto,
@@ -88,13 +88,6 @@ public class UserController {
     }
 
     return ResponseEntity.ok(DvApiResponse.of(true));
-  }
-
-  @GetMapping("/profile-image")
-  public ResponseEntity<DvApiResponse<String>> getProfileImage(
-      @AuthenticationPrincipal Long userId) {
-    String profileImageUrl = userService.getProfileImage(userId);
-    return ResponseEntity.ok(DvApiResponse.of(profileImageUrl));
   }
 
   @GetMapping("/validate-username")

--- a/src/main/java/org/richardstallman/dvback/domain/user/controller/UserController.java
+++ b/src/main/java/org/richardstallman/dvback/domain/user/controller/UserController.java
@@ -3,6 +3,8 @@ package org.richardstallman.dvback.domain.user.controller;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.richardstallman.dvback.common.DvApiResponse;
@@ -17,6 +19,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RestController
@@ -38,11 +41,14 @@ public class UserController {
     return ResponseEntity.ok("Logged out successfully");
   }
 
-  @PutMapping("/info")
+  @PostMapping("/info")
   public ResponseEntity<DvApiResponse<UserResponseDto>> updateUserInfo(
       @AuthenticationPrincipal Long userId,
-      @Valid @RequestBody final UserRequestDto userRequestDto) {
-    final UserResponseDto userResponseDto = userService.updateUserInfo(userId, userRequestDto);
+      @RequestPart("userInfo") @Valid final UserRequestDto userRequestDto,
+      @RequestPart("profileImage") @NotNull MultipartFile profileImage)
+      throws IOException {
+    final UserResponseDto userResponseDto =
+        userService.updateUserInfo(userId, userRequestDto, profileImage);
     return ResponseEntity.ok(DvApiResponse.of(userResponseDto));
   }
 
@@ -83,13 +89,15 @@ public class UserController {
   }
 
   @GetMapping("/profile-image")
-  public ResponseEntity<DvApiResponse<String>> getProfileImage(@AuthenticationPrincipal Long userId) {
+  public ResponseEntity<DvApiResponse<String>> getProfileImage(
+      @AuthenticationPrincipal Long userId) {
     String profileImageUrl = userService.getProfileImage(userId);
     return ResponseEntity.ok(DvApiResponse.of(profileImageUrl));
   }
 
   @GetMapping("/validate-username")
-  public ResponseEntity<DvApiResponse<Boolean>> validateUsername(@RequestParam("username") String username) {
+  public ResponseEntity<DvApiResponse<Boolean>> validateUsername(
+      @RequestParam("username") String username) {
 
     if (userService.existsByUsername(username)) {
       return ResponseEntity.ok(DvApiResponse.of(true));

--- a/src/main/java/org/richardstallman/dvback/domain/user/controller/UserController.java
+++ b/src/main/java/org/richardstallman/dvback/domain/user/controller/UserController.java
@@ -12,6 +12,7 @@ import org.richardstallman.dvback.domain.user.converter.UserConverter;
 import org.richardstallman.dvback.domain.user.domain.request.UserRequestDto;
 import org.richardstallman.dvback.domain.user.domain.response.UserLoginResponseDto;
 import org.richardstallman.dvback.domain.user.domain.response.UserResponseDto;
+import org.richardstallman.dvback.domain.user.service.UserPostService;
 import org.richardstallman.dvback.domain.user.service.UserService;
 import org.richardstallman.dvback.global.jwt.JwtUtil;
 import org.richardstallman.dvback.global.oauth.service.TokenService;
@@ -29,6 +30,7 @@ public class UserController {
 
   private final TokenService tokenService;
   private final UserService userService;
+  private final UserPostService userPostService;
   private final UserConverter userConverter;
   private final JwtUtil jwtUtil;
 
@@ -48,7 +50,7 @@ public class UserController {
       @RequestPart("profileImage") @NotNull MultipartFile profileImage)
       throws IOException {
     final UserResponseDto userResponseDto =
-        userService.updateUserInfo(userId, userRequestDto, profileImage);
+        userPostService.updateUserInfo(userId, userRequestDto, profileImage);
     return ResponseEntity.ok(DvApiResponse.of(userResponseDto));
   }
 

--- a/src/main/java/org/richardstallman/dvback/domain/user/converter/UserConverter.java
+++ b/src/main/java/org/richardstallman/dvback/domain/user/converter/UserConverter.java
@@ -31,6 +31,7 @@ public class UserConverter {
         .id(userEntity.getId())
         .socialId(userEntity.getSocialId())
         .email(userEntity.getEmail())
+        .username(userEntity.getUsername())
         .name(userEntity.getName())
         .nickname(userEntity.getNickname())
         .s3ProfileImageUrl(userEntity.getS3ProfileImageUrl())

--- a/src/main/java/org/richardstallman/dvback/domain/user/converter/UserConverter.java
+++ b/src/main/java/org/richardstallman/dvback/domain/user/converter/UserConverter.java
@@ -41,14 +41,7 @@ public class UserConverter {
   }
 
   public UserEntity kakaoInfoToUserEntity(KakaoUserInfo kakaoUserInfo) {
-    return new UserEntity(
-        kakaoUserInfo.getId(),
-        kakaoUserInfo.getEmail(),
-        kakaoUserInfo.getNickname(),
-        kakaoUserInfo.getNickname(),
-        kakaoUserInfo.getProfileImage(),
-        null,
-        null);
+    return new UserEntity(kakaoUserInfo.getId(), kakaoUserInfo.getEmail());
   }
 
   public UserResponseDto fromDomainToDto(UserDomain userDomain) {

--- a/src/main/java/org/richardstallman/dvback/domain/user/converter/UserConverter.java
+++ b/src/main/java/org/richardstallman/dvback/domain/user/converter/UserConverter.java
@@ -17,6 +17,7 @@ public class UserConverter {
         userDomain.getId(),
         userDomain.getSocialId(),
         userDomain.getEmail(),
+        userDomain.getUsername(),
         userDomain.getName(),
         userDomain.getNickname(),
         userDomain.getS3ProfileImageUrl(),
@@ -55,6 +56,7 @@ public class UserConverter {
         userDomain.getId(),
         userDomain.getSocialId(),
         userDomain.getEmail(),
+        userDomain.getUsername(),
         userDomain.getName(),
         userDomain.getNickname(),
         userDomain.getS3ProfileImageUrl(),
@@ -84,6 +86,7 @@ public class UserConverter {
         userResponseDto.userId(),
         userResponseDto.socialId(),
         userResponseDto.email(),
+        userResponseDto.username(),
         userResponseDto.name(),
         userResponseDto.nickname(),
         userResponseDto.s3ProfileImageUrl(),
@@ -94,6 +97,6 @@ public class UserConverter {
 
   public UserLoginResponseDto forSignUp(UserResponseDto userResponseDto, String type) {
     return new UserLoginResponseDto(
-        type, userResponseDto.userId(), null, null, null, null, null, null, null, null);
+        type, userResponseDto.userId(), null, null, null, null, null, null, null, null, null);
   }
 }

--- a/src/main/java/org/richardstallman/dvback/domain/user/domain/UserDomain.java
+++ b/src/main/java/org/richardstallman/dvback/domain/user/domain/UserDomain.java
@@ -1,6 +1,6 @@
 package org.richardstallman.dvback.domain.user.domain;
 
-import java.util.Date;
+import java.time.LocalDate;
 import lombok.Builder;
 import lombok.Getter;
 import org.richardstallman.dvback.common.constant.CommonConstants;
@@ -13,11 +13,12 @@ public class UserDomain {
   private Long id;
   private String socialId;
   private String email;
+  private String username;
   private String name;
   private String nickname;
   private String s3ProfileImageUrl;
   private Boolean leave;
   private CommonConstants.Gender gender;
-  private Date birthdate;
+  private LocalDate birthdate;
   private JobDomain job;
 }

--- a/src/main/java/org/richardstallman/dvback/domain/user/domain/request/UserRequestDto.java
+++ b/src/main/java/org/richardstallman/dvback/domain/user/domain/request/UserRequestDto.java
@@ -1,12 +1,12 @@
 package org.richardstallman.dvback.domain.user.domain.request;
 
 import jakarta.validation.constraints.NotNull;
-import java.util.Date;
+import java.time.LocalDate;
 import org.richardstallman.dvback.common.constant.CommonConstants;
 
 public record UserRequestDto(
     @NotNull(message = "Name is required") String name,
     @NotNull(message = "Username is required") String username,
     @NotNull(message = "Nickname is required") String nickname,
-    @NotNull(message = "Birthdate is required") Date birthdate,
+    @NotNull(message = "Birthdate is required") LocalDate birthdate,
     @NotNull(message = "Gender is required") CommonConstants.Gender gender) {}

--- a/src/main/java/org/richardstallman/dvback/domain/user/domain/request/UserRequestDto.java
+++ b/src/main/java/org/richardstallman/dvback/domain/user/domain/request/UserRequestDto.java
@@ -5,6 +5,8 @@ import java.util.Date;
 import org.richardstallman.dvback.common.constant.CommonConstants;
 
 public record UserRequestDto(
+    @NotNull(message = "Name is required") String name,
+    @NotNull(message = "Username is required") String username,
     @NotNull(message = "Nickname is required") String nickname,
     @NotNull(message = "Birthdate is required") Date birthdate,
     @NotNull(message = "Gender is required") CommonConstants.Gender gender) {}

--- a/src/main/java/org/richardstallman/dvback/domain/user/domain/response/UserLoginResponseDto.java
+++ b/src/main/java/org/richardstallman/dvback/domain/user/domain/response/UserLoginResponseDto.java
@@ -1,7 +1,7 @@
 package org.richardstallman.dvback.domain.user.domain.response;
 
 import jakarta.validation.constraints.NotNull;
-import java.util.Date;
+import java.time.LocalDate;
 import org.richardstallman.dvback.common.constant.CommonConstants;
 
 public record UserLoginResponseDto(
@@ -9,9 +9,10 @@ public record UserLoginResponseDto(
     Long userId,
     String socialId,
     String email,
+    String username,
     String name,
     String nickname,
     String s3ProfileImageUrl,
     Boolean leave,
     CommonConstants.Gender gender,
-    Date birthdate) {}
+    LocalDate birthdate) {}

--- a/src/main/java/org/richardstallman/dvback/domain/user/domain/response/UserResponseDto.java
+++ b/src/main/java/org/richardstallman/dvback/domain/user/domain/response/UserResponseDto.java
@@ -1,16 +1,17 @@
 package org.richardstallman.dvback.domain.user.domain.response;
 
 import jakarta.validation.constraints.NotNull;
-import java.util.Date;
+import java.time.LocalDate;
 import org.richardstallman.dvback.common.constant.CommonConstants;
 
 public record UserResponseDto(
     @NotNull Long userId,
     @NotNull String socialId,
     @NotNull String email,
+    @NotNull String username,
     @NotNull String name,
     @NotNull String nickname,
     @NotNull String s3ProfileImageUrl,
     @NotNull Boolean leave,
     @NotNull CommonConstants.Gender gender,
-    @NotNull Date birthdate) {}
+    @NotNull LocalDate birthdate) {}

--- a/src/main/java/org/richardstallman/dvback/domain/user/entity/UserEntity.java
+++ b/src/main/java/org/richardstallman/dvback/domain/user/entity/UserEntity.java
@@ -1,12 +1,11 @@
 package org.richardstallman.dvback.domain.user.entity;
 
 import jakarta.persistence.*;
-import java.util.Date;
+import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.richardstallman.dvback.common.constant.CommonConstants;
-import org.richardstallman.dvback.domain.job.entity.JobEntity;
 
 @Entity
 @Getter
@@ -27,6 +26,9 @@ public class UserEntity {
   private String email;
 
   @Column(nullable = false)
+  private String username;
+
+  @Column(nullable = false)
   private String name;
 
   @Column(nullable = false, unique = true)
@@ -40,7 +42,7 @@ public class UserEntity {
   @Enumerated(EnumType.STRING)
   private CommonConstants.Gender gender;
 
-  @Column private Date birthdate;
+  @Column private LocalDate birthdate;
 
   //  @OneToOne(fetch = FetchType.EAGER)
   //  @JoinColumn(name = "job_id", nullable = false)
@@ -53,7 +55,9 @@ public class UserEntity {
       String nickname,
       String s3ProfileImageUrl,
       CommonConstants.Gender gender,
-      JobEntity job) {
+      LocalDate birthdate
+      //    JobEntity job
+      ) {
     this.socialId = socialId;
     this.email = email;
     this.name = name;
@@ -61,19 +65,25 @@ public class UserEntity {
     this.s3ProfileImageUrl = s3ProfileImageUrl;
     this.leave = false;
     this.gender = gender;
-    this.birthdate = new Date();
+    this.birthdate = birthdate;
     //    this.job = job;
   }
 
   public UserEntity updatedUserEntity(
-      String nickname, Date birthdate, CommonConstants.Gender gender) {
+      String username,
+      String name,
+      String nickname,
+      String s3ProfileImageUrl,
+      LocalDate birthdate,
+      CommonConstants.Gender gender) {
     return new UserEntity(
         this.id,
         this.socialId,
         this.email,
-        this.name,
+        username,
+        name,
         nickname,
-        this.s3ProfileImageUrl,
+        s3ProfileImageUrl,
         this.leave,
         gender,
         birthdate

--- a/src/main/java/org/richardstallman/dvback/domain/user/entity/UserEntity.java
+++ b/src/main/java/org/richardstallman/dvback/domain/user/entity/UserEntity.java
@@ -25,13 +25,11 @@ public class UserEntity {
   @Column(nullable = false)
   private String email;
 
-  @Column(nullable = false)
   private String username;
 
-  @Column(nullable = false)
   private String name;
 
-  @Column(nullable = false, unique = true)
+  @Column(unique = true)
   private String nickname;
 
   @Column(name = "s3_profile_image_url")

--- a/src/main/java/org/richardstallman/dvback/domain/user/entity/UserEntity.java
+++ b/src/main/java/org/richardstallman/dvback/domain/user/entity/UserEntity.java
@@ -48,25 +48,9 @@ public class UserEntity {
   //  @JoinColumn(name = "job_id", nullable = false)
   //  private JobEntity job;
 
-  public UserEntity(
-      String socialId,
-      String email,
-      String name,
-      String nickname,
-      String s3ProfileImageUrl,
-      CommonConstants.Gender gender,
-      LocalDate birthdate
-      //    JobEntity job
-      ) {
+  public UserEntity(String socialId, String email) {
     this.socialId = socialId;
     this.email = email;
-    this.name = name;
-    this.nickname = nickname;
-    this.s3ProfileImageUrl = s3ProfileImageUrl;
-    this.leave = false;
-    this.gender = gender;
-    this.birthdate = birthdate;
-    //    this.job = job;
   }
 
   public UserEntity updatedUserEntity(

--- a/src/main/java/org/richardstallman/dvback/domain/user/repository/UserJpaRepository.java
+++ b/src/main/java/org/richardstallman/dvback/domain/user/repository/UserJpaRepository.java
@@ -9,4 +9,6 @@ import org.springframework.stereotype.Repository;
 public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
 
   Optional<UserEntity> findBySocialId(String socialId);
+
+  boolean existsByUsername(String username);
 }

--- a/src/main/java/org/richardstallman/dvback/domain/user/repository/UserJpaRepository.java
+++ b/src/main/java/org/richardstallman/dvback/domain/user/repository/UserJpaRepository.java
@@ -11,4 +11,6 @@ public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
   Optional<UserEntity> findBySocialId(String socialId);
 
   boolean existsByUsername(String username);
+
+  Optional<String> findProfileImageUrlById(Long id);
 }

--- a/src/main/java/org/richardstallman/dvback/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/richardstallman/dvback/domain/user/repository/UserRepository.java
@@ -12,4 +12,6 @@ public interface UserRepository {
   UserDomain save(UserDomain userDomain);
 
   boolean existsByUsername(String username);
+
+  Optional<String> findProfileImageUrlById(Long userId);
 }

--- a/src/main/java/org/richardstallman/dvback/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/richardstallman/dvback/domain/user/repository/UserRepository.java
@@ -10,4 +10,6 @@ public interface UserRepository {
   Optional<UserDomain> findBySocialId(String socialId);
 
   UserDomain save(UserDomain userDomain);
+
+  boolean existsByUsername(String username);
 }

--- a/src/main/java/org/richardstallman/dvback/domain/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/org/richardstallman/dvback/domain/user/repository/UserRepositoryImpl.java
@@ -33,4 +33,9 @@ public class UserRepositoryImpl implements UserRepository {
   public boolean existsByUsername(String username) {
     return userJpaRepository.existsByUsername(username);
   }
+
+  @Override
+  public Optional<String> findProfileImageUrlById(Long userId) {
+    return userJpaRepository.findProfileImageUrlById(userId);
+  }
 }

--- a/src/main/java/org/richardstallman/dvback/domain/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/org/richardstallman/dvback/domain/user/repository/UserRepositoryImpl.java
@@ -28,4 +28,9 @@ public class UserRepositoryImpl implements UserRepository {
     return userConverter.fromEntityToDomain(
         userJpaRepository.save(userConverter.fromDomainToEntity(userDomain)));
   }
+
+  @Override
+  public boolean existsByUsername(String username) {
+    return userJpaRepository.existsByUsername(username);
+  }
 }

--- a/src/main/java/org/richardstallman/dvback/domain/user/service/UserPostService.java
+++ b/src/main/java/org/richardstallman/dvback/domain/user/service/UserPostService.java
@@ -1,0 +1,12 @@
+package org.richardstallman.dvback.domain.user.service;
+
+import java.io.IOException;
+import org.richardstallman.dvback.domain.user.domain.request.UserRequestDto;
+import org.richardstallman.dvback.domain.user.domain.response.UserResponseDto;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface UserPostService {
+
+  UserResponseDto updateUserInfo(
+      Long userId, UserRequestDto userRequestDto, MultipartFile profileImage) throws IOException;
+}

--- a/src/main/java/org/richardstallman/dvback/domain/user/service/UserPostServiceImpl.java
+++ b/src/main/java/org/richardstallman/dvback/domain/user/service/UserPostServiceImpl.java
@@ -1,0 +1,85 @@
+package org.richardstallman.dvback.domain.user.service;
+
+import static org.richardstallman.dvback.common.constant.CommonConstants.FileType.PROFILE_IMAGE;
+import static org.richardstallman.dvback.global.util.TimeUtil.generateExpirationDateTime;
+import static org.richardstallman.dvback.global.util.TimeUtil.getCurrentDateTime;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.richardstallman.dvback.client.s3.service.S3Service;
+import org.richardstallman.dvback.domain.coupon.converter.CouponConverter;
+import org.richardstallman.dvback.domain.coupon.repository.CouponRepository;
+import org.richardstallman.dvback.domain.user.converter.UserConverter;
+import org.richardstallman.dvback.domain.user.domain.UserDomain;
+import org.richardstallman.dvback.domain.user.domain.request.UserRequestDto;
+import org.richardstallman.dvback.domain.user.domain.response.UserResponseDto;
+import org.richardstallman.dvback.domain.user.entity.UserEntity;
+import org.richardstallman.dvback.domain.user.repository.UserRepository;
+import org.richardstallman.dvback.global.config.coupons.CouponsConfig;
+import org.richardstallman.dvback.global.oauth.service.CookieService;
+import org.richardstallman.dvback.global.oauth.service.TokenService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserPostServiceImpl implements UserPostService {
+
+  private final UserRepository userRepository;
+  private final UserConverter userConverter;
+  private final CookieService cookieService;
+  private final TokenService tokenService;
+  private final CouponRepository couponRepository;
+  private final CouponsConfig couponsConfig;
+  private final CouponConverter couponConverter;
+  private final S3Service s3Service;
+
+  @Transactional
+  public UserResponseDto updateUserInfo(
+      Long userId, UserRequestDto userRequestDto, MultipartFile profileImage) throws IOException {
+    UserDomain user = findUserById(userId);
+    UserEntity userEntity = userConverter.fromDomainToEntity(user);
+
+    String profileImageUrl = s3Service.uploadImageToS3(profileImage, PROFILE_IMAGE, userId);
+
+    UserEntity updatedUser =
+        userEntity.updatedUserEntity(
+            userRequestDto.username(),
+            userRequestDto.name(),
+            userRequestDto.nickname(),
+            profileImageUrl,
+            userRequestDto.birthdate(),
+            userRequestDto.gender());
+
+    user = userRepository.save(userConverter.fromEntityToDomain(updatedUser));
+
+    LocalDateTime now = getCurrentDateTime();
+    LocalDateTime expireAt = generateExpirationDateTime(now);
+    for (CouponsConfig.WelcomeCoupons welcomeCoupons : couponsConfig.getWelcomeCoupons()) {
+      couponRepository.save(
+          couponConverter.fromWelcomeCouponToDomain(welcomeCoupons, user, now, expireAt));
+    }
+
+    return new UserResponseDto(
+        updatedUser.getId(),
+        updatedUser.getSocialId(),
+        updatedUser.getEmail(),
+        updatedUser.getUsername(),
+        updatedUser.getName(),
+        updatedUser.getNickname(),
+        updatedUser.getS3ProfileImageUrl(),
+        updatedUser.getLeave(),
+        updatedUser.getGender(),
+        updatedUser.getBirthdate());
+  }
+
+  private UserDomain findUserById(Long userId) {
+    return userRepository
+        .findById(userId)
+        .orElseThrow(() -> new IllegalArgumentException("User not found with id: " + userId));
+  }
+}

--- a/src/main/java/org/richardstallman/dvback/domain/user/service/UserPostServiceImpl.java
+++ b/src/main/java/org/richardstallman/dvback/domain/user/service/UserPostServiceImpl.java
@@ -4,6 +4,7 @@ import static org.richardstallman.dvback.common.constant.CommonConstants.FileTyp
 import static org.richardstallman.dvback.global.util.TimeUtil.generateExpirationDateTime;
 import static org.richardstallman.dvback.global.util.TimeUtil.getCurrentDateTime;
 
+import com.vane.badwordfiltering.BadWordFiltering;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
@@ -90,6 +91,9 @@ public class UserPostServiceImpl implements UserPostService {
     if (!username.matches("^[a-zA-Z0-9]+$")) {
       throw new IllegalArgumentException("Username must contain only letters and numbers.");
     }
+    if (containsBadWord(username)) {
+      throw new IllegalArgumentException("The username contains words that are not allowed.");
+    }
 
     boolean usernameExists = userRepository.existsByUsername(username);
     if (usernameExists) {
@@ -101,5 +105,13 @@ public class UserPostServiceImpl implements UserPostService {
     if (!nickname.matches("^[a-zA-Z0-9]+$")) {
       throw new IllegalArgumentException("Nickname must contain only letters and numbers.");
     }
+    if (containsBadWord(nickname)) {
+      throw new IllegalArgumentException("The nickname contains words that are not allowed.");
+    }
+  }
+
+  private boolean containsBadWord(String value) {
+    BadWordFiltering badWordFiltering = new BadWordFiltering();
+    return badWordFiltering.check(value);
   }
 }

--- a/src/main/java/org/richardstallman/dvback/domain/user/service/UserPostServiceImpl.java
+++ b/src/main/java/org/richardstallman/dvback/domain/user/service/UserPostServiceImpl.java
@@ -42,8 +42,11 @@ public class UserPostServiceImpl implements UserPostService {
   public UserResponseDto updateUserInfo(
       Long userId, UserRequestDto userRequestDto, MultipartFile profileImage) throws IOException {
     UserDomain user = findUserById(userId);
-    UserEntity userEntity = userConverter.fromDomainToEntity(user);
 
+    validateUsername(userRequestDto.username());
+    validateNickname(userRequestDto.nickname());
+
+    UserEntity userEntity = userConverter.fromDomainToEntity(user);
     String profileImageUrl = s3Service.uploadImageToS3(profileImage, PROFILE_IMAGE, userId);
 
     UserEntity updatedUser =
@@ -81,5 +84,22 @@ public class UserPostServiceImpl implements UserPostService {
     return userRepository
         .findById(userId)
         .orElseThrow(() -> new IllegalArgumentException("User not found with id: " + userId));
+  }
+
+  private void validateUsername(String username) {
+    if (!username.matches("^[a-zA-Z0-9]+$")) {
+      throw new IllegalArgumentException("Username must contain only letters and numbers.");
+    }
+
+    boolean usernameExists = userRepository.existsByUsername(username);
+    if (usernameExists) {
+      throw new IllegalArgumentException("Username is already taken.");
+    }
+  }
+
+  private void validateNickname(String nickname) {
+    if (!nickname.matches("^[a-zA-Z0-9]+$")) {
+      throw new IllegalArgumentException("Nickname must contain only letters and numbers.");
+    }
   }
 }

--- a/src/main/java/org/richardstallman/dvback/domain/user/service/UserService.java
+++ b/src/main/java/org/richardstallman/dvback/domain/user/service/UserService.java
@@ -11,4 +11,6 @@ public interface UserService {
   UserResponseDto getUserInfo(Long userId);
 
   void logout(HttpServletResponse response, String RefreshToken);
+
+  boolean existsByUsername(String username);
 }

--- a/src/main/java/org/richardstallman/dvback/domain/user/service/UserService.java
+++ b/src/main/java/org/richardstallman/dvback/domain/user/service/UserService.java
@@ -1,12 +1,15 @@
 package org.richardstallman.dvback.domain.user.service;
 
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import org.richardstallman.dvback.domain.user.domain.request.UserRequestDto;
 import org.richardstallman.dvback.domain.user.domain.response.UserResponseDto;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface UserService {
 
-  UserResponseDto updateUserInfo(Long userId, UserRequestDto userRequestDto);
+  UserResponseDto updateUserInfo(
+      Long userId, UserRequestDto userRequestDto, MultipartFile profileImage) throws IOException;
 
   UserResponseDto getUserInfo(Long userId);
 

--- a/src/main/java/org/richardstallman/dvback/domain/user/service/UserService.java
+++ b/src/main/java/org/richardstallman/dvback/domain/user/service/UserService.java
@@ -1,15 +1,9 @@
 package org.richardstallman.dvback.domain.user.service;
 
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import org.richardstallman.dvback.domain.user.domain.request.UserRequestDto;
 import org.richardstallman.dvback.domain.user.domain.response.UserResponseDto;
-import org.springframework.web.multipart.MultipartFile;
 
 public interface UserService {
-
-  UserResponseDto updateUserInfo(
-      Long userId, UserRequestDto userRequestDto, MultipartFile profileImage) throws IOException;
 
   UserResponseDto getUserInfo(Long userId);
 

--- a/src/main/java/org/richardstallman/dvback/domain/user/service/UserService.java
+++ b/src/main/java/org/richardstallman/dvback/domain/user/service/UserService.java
@@ -13,4 +13,6 @@ public interface UserService {
   void logout(HttpServletResponse response, String RefreshToken);
 
   boolean existsByUsername(String username);
+
+  String getProfileImage(Long userId);
 }

--- a/src/main/java/org/richardstallman/dvback/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/org/richardstallman/dvback/domain/user/service/UserServiceImpl.java
@@ -61,6 +61,11 @@ public class UserServiceImpl implements UserService {
     tokenService.deleteRefreshTokenByRefreshToken(refreshToken);
   }
 
+  @Override
+  public boolean existsByUsername(String username) {
+    return userRepository.existsByUsername(username);
+  }
+
   private UserDomain findUserById(Long userId) {
     return userRepository
         .findById(userId)

--- a/src/main/java/org/richardstallman/dvback/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/org/richardstallman/dvback/domain/user/service/UserServiceImpl.java
@@ -84,6 +84,13 @@ public class UserServiceImpl implements UserService {
     return userRepository.existsByUsername(username);
   }
 
+  @Override
+  public String getProfileImage(Long userId) {
+    return userRepository
+            .findProfileImageUrlById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("Profile image not found for user id: " + userId));
+  }
+
   private UserDomain findUserById(Long userId) {
     return userRepository
         .findById(userId)

--- a/src/main/java/org/richardstallman/dvback/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/org/richardstallman/dvback/domain/user/service/UserServiceImpl.java
@@ -1,30 +1,15 @@
 package org.richardstallman.dvback.domain.user.service;
 
-import static org.richardstallman.dvback.common.constant.CommonConstants.FileType.PROFILE_IMAGE;
-import static org.richardstallman.dvback.global.util.TimeUtil.generateExpirationDateTime;
-import static org.richardstallman.dvback.global.util.TimeUtil.getCurrentDateTime;
-
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.richardstallman.dvback.client.s3.service.S3Service;
-import org.richardstallman.dvback.domain.coupon.converter.CouponConverter;
-import org.richardstallman.dvback.domain.coupon.repository.CouponRepository;
 import org.richardstallman.dvback.domain.user.converter.UserConverter;
 import org.richardstallman.dvback.domain.user.domain.UserDomain;
-import org.richardstallman.dvback.domain.user.domain.request.UserRequestDto;
 import org.richardstallman.dvback.domain.user.domain.response.UserResponseDto;
-import org.richardstallman.dvback.domain.user.entity.UserEntity;
 import org.richardstallman.dvback.domain.user.repository.UserRepository;
-import org.richardstallman.dvback.global.config.coupons.CouponsConfig;
-import org.richardstallman.dvback.global.config.coupons.CouponsConfig.WelcomeCoupons;
 import org.richardstallman.dvback.global.oauth.service.CookieService;
 import org.richardstallman.dvback.global.oauth.service.TokenService;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @Service
@@ -35,49 +20,6 @@ public class UserServiceImpl implements UserService {
   private final UserConverter userConverter;
   private final CookieService cookieService;
   private final TokenService tokenService;
-  private final CouponRepository couponRepository;
-  private final CouponsConfig couponsConfig;
-  private final CouponConverter couponConverter;
-  private final S3Service s3Service;
-
-  @Transactional
-  public UserResponseDto updateUserInfo(
-      Long userId, UserRequestDto userRequestDto, MultipartFile profileImage) throws IOException {
-    UserDomain user = findUserById(userId);
-    UserEntity userEntity = userConverter.fromDomainToEntity(user);
-
-    String profileImageUrl = s3Service.uploadImageToS3(profileImage, PROFILE_IMAGE, userId);
-
-    UserEntity updatedUser =
-        userEntity.updatedUserEntity(
-            userRequestDto.username(),
-            userRequestDto.name(),
-            userRequestDto.nickname(),
-            profileImageUrl,
-            userRequestDto.birthdate(),
-            userRequestDto.gender());
-
-    user = userRepository.save(userConverter.fromEntityToDomain(updatedUser));
-
-    LocalDateTime now = getCurrentDateTime();
-    LocalDateTime expireAt = generateExpirationDateTime(now);
-    for (WelcomeCoupons welcomeCoupons : couponsConfig.getWelcomeCoupons()) {
-      couponRepository.save(
-          couponConverter.fromWelcomeCouponToDomain(welcomeCoupons, user, now, expireAt));
-    }
-
-    return new UserResponseDto(
-        updatedUser.getId(),
-        updatedUser.getSocialId(),
-        updatedUser.getEmail(),
-        updatedUser.getUsername(),
-        updatedUser.getName(),
-        updatedUser.getNickname(),
-        updatedUser.getS3ProfileImageUrl(),
-        updatedUser.getLeave(),
-        updatedUser.getGender(),
-        updatedUser.getBirthdate());
-  }
 
   @Override
   public UserResponseDto getUserInfo(Long userId) {

--- a/src/main/java/org/richardstallman/dvback/global/converter/MultipartJackson2HttpMessageConverter.java
+++ b/src/main/java/org/richardstallman/dvback/global/converter/MultipartJackson2HttpMessageConverter.java
@@ -1,0 +1,23 @@
+package org.richardstallman.dvback.global.converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MultipartJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+  public MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
+    super(objectMapper, MediaType.APPLICATION_JSON, MediaType.MULTIPART_FORM_DATA);
+  }
+
+  @Override
+  public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+    return false;
+  }
+
+  @Override
+  protected boolean canWrite(MediaType mediaType) {
+    return false;
+  }
+}

--- a/src/main/java/org/richardstallman/dvback/global/oauth/KakaoUserInfo.java
+++ b/src/main/java/org/richardstallman/dvback/global/oauth/KakaoUserInfo.java
@@ -21,16 +21,4 @@ public class KakaoUserInfo {
     }
     return (String) account.get("email");
   }
-
-  public String getNickname() {
-    Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
-    Map<String, Object> profile = (Map<String, Object>) account.get("profile");
-    return (String) profile.get("nickname");
-  }
-
-  public String getProfileImage() {
-    Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
-    Map<String, Object> profile = (Map<String, Object>) account.get("profile");
-    return (String) profile.get("thumbnail_image_url");
-  }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -6,7 +6,7 @@ spring:
     driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
@@ -27,7 +27,7 @@ spring:
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post
             client-name: kakao
-            scope: profile_nickname, profile_image, account_email
+            scope: account_email
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치

- DV-162-회원-예외처리

## 📚 작업한 내용

- 회원 정보 입력 수정
- username, name, nickname 예외 처리

## 📍 참고 사항
- https://www.notion.so/10a61cc339838071acc6d645fd3d3f46?p=d823b4791d5d4999a3455ef62f28db62&pm=c
 ㄴ postman 및 build 성공

## 📝 리뷰 중점 사안(선택)
- 현재 노션 아래를 보면 test코드에서 'requestParts 지원이 안되는 오류'에 대한 내용이 있는데 이게 도저히 해결이 안돼서 일단은 `requestparts` 부분을 `responsefields`로 테스트 코드를 작업했습니다. 프론트팀에는 postman을 전달하는게 최선일 것 같은데 혹시 관련해서 아는 부분이 있다면 공유 부탁드려요.
- userPostService를 생성한 이유는 기존의 userService에 작업을 하면 순환참조 에러가 생겨서 그렇습니다. 이것도 더 좋은 방법이 있다면 알려주세요.
